### PR TITLE
Add text-to-avatar action pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,27 @@ Human Rendering is defined in the class **HAVLNCE** of [HASimulator/enviorments.
 
 Human Rendering uses child threads for timing and the main thread for adding / removing human models and recalculating the required navmesh in real time.
 
+## 🧍 Text-to-Avatar Action Assets
+
+This repository also includes an experimental `havln3` asset pipeline for turning
+a one-sentence human action description into HA-VLN/HAPS-compatible animated GLB
+frames:
+
+- selects a matching ViCo/Mixamo avatar while preserving the avatar's original
+  mesh, UVs, skin weights, and textures;
+- loads existing Kimodo `.npz` or GEM `smpl_params.pt` motion outputs;
+- retargets SMPL-22/GEM/Kimodo motion onto the avatar rig;
+- uses calibrated two-bone leg IK when Kimodo `posed_joints` are available, so
+  hip-knee-ankle bending follows the target avatar's knee pole instead of
+  folding backward;
+- exports Habitat-safe materials and a lightweight mesh shell so side/back
+  cameras see body volume instead of paper-thin clothing surfaces;
+- exports `Data/HAPS2_0/<asset>/frameXXX.glb`,
+  `frameXXX.object_config.json`, `skeleton.json`, and `persona.json`.
+
+See [docs/avatar_action_pipeline.md](docs/avatar_action_pipeline.md) for commands,
+retargeting rules, and tuning options.
+
 In the first use, the navmesh will be automatically calculated and saved to support operations such as collision calculation, and the subsequent use will directly load the previously generated navmesh. To enable human rendering, modify the following settings in [HAVLN-CE task config](HASimulator/config/HAVLNCE_task.yaml):
 
 ```
@@ -443,4 +464,3 @@ If you find this repository or our paper useful, please consider **starring** th
 This project is licensed under the MIT License. For more details, see the [LICENSE](LICENSE) file.
 
 ---
-

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -88,13 +88,14 @@ For stationary acrobatics such as standing backflips, add:
 flip's pitch/roll. `--foot-contact-lock` detects low support/landing feet and
 keeps the whole body anchored to the contact point with a short blend at the
 segment edges. It also stabilizes contact-foot orientation by default, aligning
-the toe direction to the initial stance direction, compensating for root yaw
-stabilization, and aligning the foot-up axis to the floor normal so landing
-frames do not inherit rolled or twisted ankles from the generated motion. During
-contact it also neutralizes toe-base curl so the shoe mesh does not flip even
-when the source motion twists the toe joint. Use `--no-foot-orientation-lock`
-only for debugging. Tune `--foot-contact-height` and `--foot-lock-blend-frames`
-if a motion source marks contact too early or too late.
+the toe direction to the target rig's body-facing direction, compensating for
+root yaw stabilization, and aligning the foot-up axis to the floor normal so
+landing frames do not inherit rolled or twisted ankles from the generated
+motion. During contact it also neutralizes toe-base curl so the shoe mesh does
+not flip even when the source motion twists the toe joint. Use
+`--no-foot-orientation-lock` only for debugging. Tune `--foot-contact-height`
+and `--foot-lock-blend-frames` if a motion source marks contact too early or too
+late.
 
 ## Habitat Material And Thickness
 

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -87,8 +87,14 @@ For stationary acrobatics such as standing backflips, add:
 `--stabilize-root-yaw` removes unwanted horizontal spin while preserving the
 flip's pitch/roll. `--foot-contact-lock` detects low support/landing feet and
 keeps the whole body anchored to the contact point with a short blend at the
-segment edges. Tune `--foot-contact-height` and `--foot-lock-blend-frames` if a
-motion source marks contact too early or too late.
+segment edges. It also stabilizes contact-foot orientation by default, aligning
+the toe direction to the initial stance direction, compensating for root yaw
+stabilization, and aligning the foot-up axis to the floor normal so landing
+frames do not inherit rolled or twisted ankles from the generated motion. During
+contact it also neutralizes toe-base curl so the shoe mesh does not flip even
+when the source motion twists the toe joint. Use `--no-foot-orientation-lock`
+only for debugging. Tune `--foot-contact-height` and `--foot-lock-blend-frames`
+if a motion source marks contact too early or too late.
 
 ## Habitat Material And Thickness
 

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -1,0 +1,91 @@
+# Avatar Action Pipeline
+
+This pipeline turns one person/action sentence into a HA-VLN/ViCo-compatible
+textured human asset:
+
+1. Select the best matching ViCo/Mixamo avatar GLB from an avatar library.
+2. Load an existing GEM/Kimodo motion output, or call `kimodo_gen`.
+3. Retarget SMPL-22/Kimodo local rotations onto the selected avatar's own skin joints.
+   When posed joints are available, legs use calibrated two-bone IK so the
+   target avatar's own knee pole controls hip-knee-ankle bending.
+4. Export static HAPS frames while preserving the original avatar mesh, UVs, skin weights,
+   base-color textures, and PBR materials.
+5. Add a lightweight visible shell and Habitat-safe material flags so side/back
+   cameras do not collapse thin clothing surfaces into paper-like cutouts.
+6. Write `skeleton.json`, `persona.json`, `frameXXX.glb`, and `frameXXX.object_config.json`.
+
+The key compatibility rule is: do not project a ViCo texture onto a different SMPL-X
+topology unless you explicitly want that lossy transfer. The stable path is to keep
+the original skinned avatar and drive its existing Mixamo/ViCo skeleton.
+
+Avatar selection treats large transparent texture atlases as risky for Habitat.
+A strong suit/formal match with a single alpha atlas is allowed only because the
+exporter now solidifies the mesh and forces double-sided materials; other large
+alpha avatars are heavily penalized to avoid hollow or paper-thin humans.
+
+## Existing Kimodo Motion
+
+```bash
+PYTHONPATH=src python3 scripts/generate_avatar_action.py \
+  "An office worker in a suit does a backflip and waves." \
+  --output-root outputs/demo_action \
+  --motion-npz local_experiments/kimodo_motion_backflip_wave/office_worker_backflip_then_wave_00.npz \
+  --frames 120
+```
+
+## Generate With Kimodo
+
+Run this in an environment where NVIDIA Kimodo is installed and `kimodo_gen` is on
+`PATH`:
+
+```bash
+PYTHONPATH=src python3 scripts/generate_avatar_action.py \
+  "An office worker in a suit walks forward, turns, and waves." \
+  --output-root outputs/demo_action \
+  --generator kimodo \
+  --kimodo-model Kimodo-SMPLX-RP-v1 \
+  --duration 5.0 \
+  --frames 120
+```
+
+## Override Avatar Selection
+
+```bash
+PYTHONPATH=src python3 scripts/generate_avatar_action.py \
+  "A police officer waves to the viewer." \
+  --output-root outputs/police_wave \
+  --motion-npz path/to/motion.npz \
+  --avatar-glb vico_assets_probe/models/police.glb
+```
+
+## Retarget Tuning
+
+The defaults enable calibrated two-bone leg IK when the source motion provides
+`posed_joints` such as Kimodo `.npz` outputs. The solver measures the target
+avatar bind-pose hip-knee-ankle chain, stores the target rig knee pole, then
+rebuilds each leg from the source hip-to-ankle reach while keeping the knee on
+the target rig's valid bend side.
+
+For sources without `posed_joints`, such as the current GEM `smpl_params.pt`
+loader path, the fallback deliberately damps lower-leg and foot rotations more
+than the rest of the body. This avoids backward knee bending when SMPL/GEM leg
+axes do not exactly match a ViCo/Mixamo avatar's local bone axes.
+
+Use `--rotation-scale` for the whole body, then only raise
+`--lower-leg-rotation-scale` or `--foot-rotation-scale` when the avatar rig has
+been verified to bend cleanly.
+
+Use `--no-calibrated-leg-ik` to disable the two-bone leg solver for debugging.
+
+## Habitat Material And Thickness
+
+By default each exported frame:
+
+- converts non-hair materials to `OPAQUE`;
+- converts hair/eyelash/alpha-card materials to `MASK`;
+- sets every material `doubleSided=true`;
+- adds a symmetric mesh shell (`--body-shell-thickness`, default `0.018m`) so
+  side cameras see body volume instead of a single surface.
+
+Use `--no-solidify-shell` only for debugging source mesh deformation. In HA-VLN
+recordings, leaving the shell enabled is the safer default.

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -8,11 +8,12 @@ textured human asset:
 3. Retarget SMPL-22/Kimodo local rotations onto the selected avatar's own skin joints.
    When posed joints are available, legs use calibrated two-bone IK so the
    target avatar's own knee pole controls hip-knee-ankle bending.
-4. Export static HAPS frames while preserving the original avatar mesh, UVs, skin weights,
+4. Optionally stabilize stationary action yaw and lock support/landing feet after retargeting.
+5. Export static HAPS frames while preserving the original avatar mesh, UVs, skin weights,
    base-color textures, and PBR materials.
-5. Add a lightweight visible shell and Habitat-safe material flags so side/back
+6. Add a lightweight visible shell and Habitat-safe material flags so side/back
    cameras do not collapse thin clothing surfaces into paper-like cutouts.
-6. Write `skeleton.json`, `persona.json`, `frameXXX.glb`, and `frameXXX.object_config.json`.
+7. Write `skeleton.json`, `persona.json`, `frameXXX.glb`, and `frameXXX.object_config.json`.
 
 The key compatibility rule is: do not project a ViCo texture onto a different SMPL-X
 topology unless you explicitly want that lossy transfer. The stable path is to keep
@@ -76,6 +77,18 @@ Use `--rotation-scale` for the whole body, then only raise
 been verified to bend cleanly.
 
 Use `--no-calibrated-leg-ik` to disable the two-bone leg solver for debugging.
+
+For stationary acrobatics such as standing backflips, add:
+
+```bash
+--stabilize-root-yaw --foot-contact-lock
+```
+
+`--stabilize-root-yaw` removes unwanted horizontal spin while preserving the
+flip's pitch/roll. `--foot-contact-lock` detects low support/landing feet and
+keeps the whole body anchored to the contact point with a short blend at the
+segment edges. Tune `--foot-contact-height` and `--foot-lock-blend-frames` if a
+motion source marks contact too early or too late.
 
 ## Habitat Material And Thickness
 

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -78,6 +78,12 @@ been verified to bend cleanly.
 
 Use `--no-calibrated-leg-ik` to disable the two-bone leg solver for debugging.
 
+Keep retargeting low-intrusion by default. `--body-relative-leg-ik` and
+`--airborne-leg-stabilization` are experimental opt-in tools for diagnosing a
+bad motion source, not default production fixes. If an airborne acrobatic pose
+folds the human into itself, prefer regenerating or selecting a cleaner
+Kimodo/GEM motion source over forcing a canonical tuck in post-processing.
+
 For stationary acrobatics such as standing backflips, add:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,10 @@ lmdb
 msgpack_numpy
 networkx
 numpy>=1.16.1
+scipy>=1.7.0
+trimesh>=3.9.0
+pygltflib>=1.15.0
+pillow>=8.0.0
 pre-commit
 torch>=1.6.0
 tqdm>=4.0.0

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -60,7 +60,19 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--foot-contact-height", type=float, default=0.12)
     parser.add_argument("--foot-lock-blend-frames", type=int, default=4)
+    parser.add_argument(
+        "--airborne-leg-stabilization",
+        action="store_true",
+        help="Experimental: stabilize airborne acrobatic leg motion in pelvis-local space before leg IK.",
+    )
+    parser.add_argument("--airborne-leg-stabilization-strength", type=float, default=0.85)
+    parser.add_argument("--airborne-tuck-reach-ratio", type=float, default=0.52)
     parser.add_argument("--no-calibrated-leg-ik", action="store_true")
+    parser.add_argument(
+        "--body-relative-leg-ik",
+        action="store_true",
+        help="Experimental: map Kimodo leg directions through pelvis-local frames before leg IK.",
+    )
     parser.add_argument("--no-solidify-shell", action="store_true")
     parser.add_argument("--body-shell-thickness", type=float, default=0.018)
     parser.add_argument("--hair-shell-thickness", type=float, default=0.006)
@@ -105,7 +117,11 @@ def main() -> None:
             foot_orientation_lock=not args.no_foot_orientation_lock,
             foot_contact_height=args.foot_contact_height,
             foot_lock_blend_frames=args.foot_lock_blend_frames,
+            airborne_leg_stabilization=args.airborne_leg_stabilization,
+            airborne_leg_stabilization_strength=args.airborne_leg_stabilization_strength,
+            airborne_tuck_reach_ratio=args.airborne_tuck_reach_ratio,
             calibrated_leg_ik=not args.no_calibrated_leg_ik,
+            body_relative_leg_ik=args.body_relative_leg_ik,
             prefer_joint_position_ik=args.joint_ik,
             solidify_shell=not args.no_solidify_shell,
             body_shell_thickness=args.body_shell_thickness,

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from havln3.pipeline import AvatarActionPipeline, AvatarActionRequest  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a textured HA-VLN/ViCo human action asset from one sentence."
+    )
+    parser.add_argument("prompt", help="One-sentence person/action description.")
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--avatar-root", type=Path, default=Path("vico_assets_probe/models"))
+    parser.add_argument("--avatar-glb", type=Path)
+    parser.add_argument("--avatar-catalog", type=Path)
+    parser.add_argument("--motion-npz", type=Path, help="Existing Kimodo .npz output.")
+    parser.add_argument("--amass-npz", type=Path, help="Optional AMASS .npz companion file.")
+    parser.add_argument("--gem-smpl-params", type=Path, help="Existing GEM smpl_params.pt file.")
+    parser.add_argument("--gem-param-group", default="body_params_global")
+    parser.add_argument("--generator", choices=["existing", "kimodo"], default="existing")
+    parser.add_argument("--kimodo-model", default="Kimodo-SMPLX-RP-v1")
+    parser.add_argument("--duration", type=float, default=5.0)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--asset-name")
+    parser.add_argument("--identity")
+    parser.add_argument("--frames", type=int, default=120)
+    parser.add_argument("--fps", type=int, default=24)
+    parser.add_argument("--target-height", type=float, default=1.72)
+    parser.add_argument("--ground-y", type=float, default=-0.2)
+    parser.add_argument("--rotation-scale", type=float, default=0.65)
+    parser.add_argument("--lower-leg-rotation-scale", type=float, default=0.18)
+    parser.add_argument("--foot-rotation-scale", type=float, default=0.35)
+    parser.add_argument("--no-root-orientation", action="store_true")
+    parser.add_argument("--preserve-root-motion", action="store_true")
+    parser.add_argument("--no-calibrated-leg-ik", action="store_true")
+    parser.add_argument("--no-solidify-shell", action="store_true")
+    parser.add_argument("--body-shell-thickness", type=float, default=0.018)
+    parser.add_argument("--hair-shell-thickness", type=float, default=0.006)
+    parser.add_argument(
+        "--joint-ik",
+        action="store_true",
+        help="Experimental: retarget from Kimodo posed_joints by bone-direction IK.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = AvatarActionPipeline().run(
+        AvatarActionRequest(
+            prompt=args.prompt,
+            output_root=args.output_root,
+            avatar_root=args.avatar_root,
+            avatar_glb=args.avatar_glb,
+            avatar_catalog=args.avatar_catalog,
+            motion_npz=args.motion_npz,
+            amass_npz=args.amass_npz,
+            gem_smpl_params=args.gem_smpl_params,
+            gem_param_group=args.gem_param_group,
+            generator=args.generator,
+            kimodo_model=args.kimodo_model,
+            duration=args.duration,
+            seed=args.seed,
+            asset_name=args.asset_name,
+            identity=args.identity,
+            frames=args.frames,
+            fps=args.fps,
+            target_height=args.target_height,
+            ground_y=args.ground_y,
+            rotation_scale=args.rotation_scale,
+            lower_leg_rotation_scale=args.lower_leg_rotation_scale,
+            foot_rotation_scale=args.foot_rotation_scale,
+            include_root_orientation=not args.no_root_orientation,
+            preserve_root_motion=args.preserve_root_motion,
+            calibrated_leg_ik=not args.no_calibrated_leg_ik,
+            prefer_joint_position_ik=args.joint_ik,
+            solidify_shell=not args.no_solidify_shell,
+            body_shell_thickness=args.body_shell_thickness,
+            hair_shell_thickness=args.hair_shell_thickness,
+        )
+    )
+    print(
+        json.dumps(
+            {
+                "asset_name": result.asset_name,
+                "asset_dir": str(result.asset_dir),
+                "avatar_glb": str(result.avatar_glb),
+                "motion_path": str(result.motion_path),
+                "report_path": str(result.report_path),
+                "skeleton_path": str(result.skeleton_path),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -43,6 +43,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--foot-rotation-scale", type=float, default=0.35)
     parser.add_argument("--no-root-orientation", action="store_true")
     parser.add_argument("--preserve-root-motion", action="store_true")
+    parser.add_argument(
+        "--stabilize-root-yaw",
+        action="store_true",
+        help="Post-process stationary flips/poses so the avatar keeps its initial horizontal facing.",
+    )
+    parser.add_argument(
+        "--foot-contact-lock",
+        action="store_true",
+        help="Post-process support/landing frames so low feet stay anchored to the floor.",
+    )
+    parser.add_argument("--foot-contact-height", type=float, default=0.12)
+    parser.add_argument("--foot-lock-blend-frames", type=int, default=4)
     parser.add_argument("--no-calibrated-leg-ik", action="store_true")
     parser.add_argument("--no-solidify-shell", action="store_true")
     parser.add_argument("--body-shell-thickness", type=float, default=0.018)
@@ -83,6 +95,10 @@ def main() -> None:
             foot_rotation_scale=args.foot_rotation_scale,
             include_root_orientation=not args.no_root_orientation,
             preserve_root_motion=args.preserve_root_motion,
+            stabilize_root_yaw=args.stabilize_root_yaw,
+            foot_contact_lock=args.foot_contact_lock,
+            foot_contact_height=args.foot_contact_height,
+            foot_lock_blend_frames=args.foot_lock_blend_frames,
             calibrated_leg_ik=not args.no_calibrated_leg_ik,
             prefer_joint_position_ik=args.joint_ik,
             solidify_shell=not args.no_solidify_shell,

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -53,6 +53,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Post-process support/landing frames so low feet stay anchored to the floor.",
     )
+    parser.add_argument(
+        "--no-foot-orientation-lock",
+        action="store_true",
+        help="Disable contact-foot orientation stabilization when --foot-contact-lock is enabled.",
+    )
     parser.add_argument("--foot-contact-height", type=float, default=0.12)
     parser.add_argument("--foot-lock-blend-frames", type=int, default=4)
     parser.add_argument("--no-calibrated-leg-ik", action="store_true")
@@ -97,6 +102,7 @@ def main() -> None:
             preserve_root_motion=args.preserve_root_motion,
             stabilize_root_yaw=args.stabilize_root_yaw,
             foot_contact_lock=args.foot_contact_lock,
+            foot_orientation_lock=not args.no_foot_orientation_lock,
             foot_contact_height=args.foot_contact_height,
             foot_lock_blend_frames=args.foot_lock_blend_frames,
             calibrated_leg_ik=not args.no_calibrated_leg_ik,

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -30,6 +30,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--gem-param-group", default="body_params_global")
     parser.add_argument("--generator", choices=["existing", "kimodo"], default="existing")
     parser.add_argument("--kimodo-model", default="Kimodo-SMPLX-RP-v1")
+    parser.add_argument("--kimodo-num-samples", type=int, default=1)
+    parser.add_argument(
+        "--no-motion-quality-select",
+        action="store_true",
+        help="Disable automatic quality ranking when Kimodo generates multiple samples.",
+    )
+    parser.add_argument("--motion-quality-min-score", type=float, default=62.0)
     parser.add_argument("--duration", type=float, default=5.0)
     parser.add_argument("--seed", type=int)
     parser.add_argument("--asset-name")
@@ -99,6 +106,9 @@ def main() -> None:
             gem_param_group=args.gem_param_group,
             generator=args.generator,
             kimodo_model=args.kimodo_model,
+            kimodo_num_samples=args.kimodo_num_samples,
+            motion_quality_select=not args.no_motion_quality_select,
+            motion_quality_min_score=args.motion_quality_min_score,
             duration=args.duration,
             seed=args.seed,
             asset_name=args.asset_name,

--- a/scripts/render_avatar_action_video.py
+++ b/scripts/render_avatar_action_video.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Render one HAPS/HA-VLN animated human asset from a camera path.
+
+The script is intentionally small and simulator-facing: it loads the exported
+`frameXXX.object_config.json` files from a HAPS asset directory, places one frame
+at a time into Habitat-Sim, and writes an RGB video from a fixed or orbit camera.
+It is useful for quickly inspecting generated humans before wiring them into
+full HA-R2R annotations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import re
+from pathlib import Path
+
+import habitat_sim
+import imageio
+import magnum as mn
+import numpy as np
+
+try:
+    import quaternion  # noqa: F401
+except Exception:
+    quaternion = None
+
+
+def frame_sort_key(path):
+    numbers = re.findall(r"\d+", path.name)
+    return int(numbers[-1]) if numbers else 0
+
+
+def parse_vec3(value):
+    parts = [float(part) for part in value.split(",")]
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("expected three comma-separated numbers")
+    return parts
+
+
+def yaw_quaternion(yaw):
+    if not hasattr(np, "quaternion"):
+        raise RuntimeError(
+            "numpy-quaternion is required by Habitat-Sim AgentState.rotation; "
+            "install it in the HA-VLN simulator environment."
+        )
+    half = yaw * 0.5
+    return np.quaternion(math.cos(half), 0.0, math.sin(half), 0.0)
+
+
+def look_yaw(camera_position, target_position):
+    direction_x = target_position[0] - camera_position[0]
+    direction_z = target_position[2] - camera_position[2]
+    return math.atan2(direction_x, -direction_z)
+
+
+def make_configuration(scene_file, width, height, gpu_device, camera_pitch):
+    backend_cfg = habitat_sim.SimulatorConfiguration()
+    backend_cfg.gpu_device_id = gpu_device
+    backend_cfg.scene_id = scene_file
+    backend_cfg.enable_physics = True
+
+    sensor_spec = habitat_sim.SensorSpec()
+    sensor_spec.uuid = "color_sensor"
+    sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
+    sensor_spec.resolution = [height, width]
+    sensor_spec.position = [0.0, 0.0, 0.0]
+    sensor_spec.orientation = [camera_pitch, 0.0, 0.0]
+
+    agent_cfg = habitat_sim.agent.AgentConfiguration()
+    agent_cfg.sensor_specifications = [sensor_spec]
+    return habitat_sim.Configuration(backend_cfg, [agent_cfg])
+
+
+def load_frame_template_ids(sim, asset_dir):
+    manager = sim.get_object_template_manager()
+    config_files = sorted(asset_dir.glob("frame*.object_config.json"), key=frame_sort_key)
+    frame_files = config_files or sorted(asset_dir.glob("frame*.glb"), key=frame_sort_key)
+    if not frame_files:
+        raise FileNotFoundError("no frame*.object_config.json or frame*.glb files found in {}".format(asset_dir))
+
+    template_ids = []
+    for frame_file in frame_files:
+        loaded = manager.load_configs(str(frame_file))
+        if not loaded:
+            raise RuntimeError("failed to load object template: {}".format(frame_file))
+        template_ids.append(loaded[0])
+    return template_ids
+
+
+def euler_degrees_to_quat(rotation_degrees):
+    return (
+        mn.Quaternion.rotation(mn.Deg(rotation_degrees[0]), mn.Vector3.x_axis())
+        * mn.Quaternion.rotation(mn.Deg(rotation_degrees[1]), mn.Vector3.y_axis())
+        * mn.Quaternion.rotation(mn.Deg(rotation_degrees[2]), mn.Vector3.z_axis())
+    )
+
+
+def set_camera(sim, camera_position, target_position):
+    state = habitat_sim.AgentState()
+    state.position = np.array(camera_position, dtype=np.float32)
+    state.rotation = yaw_quaternion(look_yaw(camera_position, target_position))
+    sim.initialize_agent(0, state)
+
+
+def render_video(args):
+    repo_root = Path(__file__).resolve().parents[1]
+    asset_dir = Path(args.asset_dir)
+    if not asset_dir.is_absolute():
+        asset_dir = repo_root / asset_dir
+    scene_file = args.scene_file
+    if scene_file is None and args.scan:
+        scene_file = str(repo_root / "Data" / "scene_datasets" / "mp3d" / args.scan / "{}.glb".format(args.scan))
+    scene_file = scene_file or "NONE"
+    if scene_file != "NONE" and not os.path.exists(scene_file):
+        raise FileNotFoundError("scene file not found: {}".format(scene_file))
+
+    cfg = make_configuration(scene_file, args.width, args.height, args.gpu_device, args.camera_pitch)
+    sim = habitat_sim.Simulator(cfg)
+    template_ids = load_frame_template_ids(sim, asset_dir)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    object_rotation = euler_degrees_to_quat(args.rotation)
+    current_object_id = None
+    frame_count = min(args.frames, len(template_ids))
+
+    try:
+        with imageio.get_writer(str(output_path), fps=args.fps) as writer:
+            for frame_index in range(frame_count):
+                if current_object_id is not None and current_object_id in sim.get_existing_object_ids():
+                    sim.remove_object(current_object_id)
+
+                current_object_id = sim.add_object(template_ids[frame_index])
+                if current_object_id == -1:
+                    raise RuntimeError("failed to add object for frame {}".format(frame_index))
+                sim.set_translation(args.translation, current_object_id)
+                sim.set_rotation(object_rotation, current_object_id)
+
+                if args.camera_mode == "orbit":
+                    angle = args.orbit_start + args.orbit_radians * (frame_index / max(frame_count - 1, 1))
+                    camera_position = [
+                        args.target[0] + math.sin(angle) * args.camera_radius,
+                        args.camera_height,
+                        args.target[2] + math.cos(angle) * args.camera_radius,
+                    ]
+                else:
+                    camera_position = args.camera_position
+
+                set_camera(sim, camera_position, args.target)
+                sim.step_physics(1.0 / 60.0)
+                observation = sim.get_sensor_observations()["color_sensor"]
+                writer.append_data(observation[:, :, :3])
+    finally:
+        if current_object_id is not None and current_object_id in sim.get_existing_object_ids():
+            sim.remove_object(current_object_id)
+        sim.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--asset-dir", required=True, help="HAPS asset directory containing frame GLBs/configs.")
+    parser.add_argument("--output", required=True, help="Output video path, for example outputs/avatar_camera.mp4.")
+    parser.add_argument("--scan", help="Matterport scan id under Data/scene_datasets/mp3d.")
+    parser.add_argument("--scene-file", help="Explicit scene .glb path. Use NONE for an empty Habitat scene.")
+    parser.add_argument("--frames", type=int, default=120)
+    parser.add_argument("--fps", type=int, default=24)
+    parser.add_argument("--width", type=int, default=960)
+    parser.add_argument("--height", type=int, default=720)
+    parser.add_argument("--gpu-device", type=int, default=0)
+    parser.add_argument("--translation", type=parse_vec3, default=[0.0, 0.0, 0.0])
+    parser.add_argument("--rotation", type=parse_vec3, default=[0.0, 0.0, 0.0])
+    parser.add_argument("--target", type=parse_vec3, default=[0.0, 0.85, 0.0])
+    parser.add_argument("--camera-mode", choices=["static", "orbit"], default="static")
+    parser.add_argument("--camera-position", type=parse_vec3, default=[0.0, 1.25, 3.2])
+    parser.add_argument("--camera-height", type=float, default=1.25)
+    parser.add_argument("--camera-radius", type=float, default=3.2)
+    parser.add_argument("--camera-pitch", type=float, default=-0.08)
+    parser.add_argument("--orbit-start", type=float, default=math.pi)
+    parser.add_argument("--orbit-radians", type=float, default=math.pi * 0.55)
+    args = parser.parse_args()
+    render_video(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_kimodo_motions.py
+++ b/scripts/score_kimodo_motions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from havln3.motion_quality import MotionQualityOptions, rank_motion_files  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Rank Kimodo/GEM motion samples before retargeting.")
+    parser.add_argument("paths", nargs="+", type=Path, help="Motion .npz/.pt files or directories.")
+    parser.add_argument("--prompt", default="", help="Action prompt used for semantic checks such as backflip.")
+    parser.add_argument("--frames", type=int, default=60)
+    parser.add_argument("--min-score", type=float, default=62.0)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--gem-param-group", default="body_params_global")
+    return parser.parse_args()
+
+
+def expand_paths(paths: list[Path]) -> list[Path]:
+    expanded: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            expanded.extend(sorted(path.glob("*.npz")))
+            expanded.extend(sorted(path.glob("*.pt")))
+        else:
+            expanded.extend(sorted(path.parent.glob(path.name)) if any(ch in path.name for ch in "*?[]") else [path])
+    return [path for path in expanded if path.exists()]
+
+
+def main() -> None:
+    args = parse_args()
+    paths = expand_paths(args.paths)
+    if not paths:
+        raise SystemExit("No existing motion files matched.")
+    reports = rank_motion_files(
+        paths,
+        prompt=args.prompt,
+        options=MotionQualityOptions(frames=args.frames, min_score=args.min_score),
+        gem_param_group=args.gem_param_group,
+    )
+    payload = {
+        "selected": reports[0].to_dict(),
+        "candidates": [report.to_dict() for report in reports],
+    }
+    text = json.dumps(payload, indent=2)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(text, encoding="utf-8")
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_kimodo_motions.py
+++ b/scripts/score_kimodo_motions.py
@@ -15,6 +15,10 @@ if str(SRC_ROOT) not in sys.path:
 from havln3.motion_quality import MotionQualityOptions, rank_motion_files  # noqa: E402
 
 
+def is_motion_candidate(path: Path) -> bool:
+    return path.suffix in {".npz", ".pt"} and not path.stem.startswith("amass_") and not path.stem.endswith("_amass")
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Rank Kimodo/GEM motion samples before retargeting.")
     parser.add_argument("paths", nargs="+", type=Path, help="Motion .npz/.pt files or directories.")
@@ -32,9 +36,11 @@ def expand_paths(paths: list[Path]) -> list[Path]:
         if path.is_dir():
             expanded.extend(sorted(path.glob("*.npz")))
             expanded.extend(sorted(path.glob("*.pt")))
+            expanded.extend(sorted(path.glob("*/*.npz")))
+            expanded.extend(sorted(path.glob("*/*.pt")))
         else:
             expanded.extend(sorted(path.parent.glob(path.name)) if any(ch in path.name for ch in "*?[]") else [path])
-    return [path for path in expanded if path.exists()]
+    return [path for path in expanded if path.exists() and is_motion_candidate(path)]
 
 
 def main() -> None:

--- a/src/havln3/__init__.py
+++ b/src/havln3/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for generating textured human action assets for HA-VLN/ViCo."""
+
+from havln3.pipeline import AvatarActionPipeline, AvatarActionRequest, AvatarActionResult
+
+__all__ = ["AvatarActionPipeline", "AvatarActionRequest", "AvatarActionResult"]

--- a/src/havln3/avatar_assets.py
+++ b/src/havln3/avatar_assets.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import re
+import base64
+import io
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from pygltflib import GLTF2
+
+_FEMALE_NAMES = {
+    "clara",
+    "elena",
+    "elizabeth",
+    "emily",
+    "erika",
+    "eve",
+    "freya",
+    "ivy",
+    "jody",
+    "kate",
+    "layla",
+    "louise",
+    "megan",
+    "mira",
+    "naomi",
+    "olivia",
+    "scarlett",
+    "shannon",
+    "sophia",
+    "sophie",
+    "yara",
+    "zara",
+}
+
+_MALE_NAMES = {
+    "adam",
+    "adrian",
+    "alex",
+    "brian",
+    "brycer",
+    "chad",
+    "dylan",
+    "elliot",
+    "ethan",
+    "felix",
+    "james",
+    "joe",
+    "julian",
+    "kenji",
+    "leonard",
+    "liam",
+    "malik",
+    "marco",
+    "marcus",
+    "morten",
+    "nico",
+    "rafael",
+    "roth",
+    "steve",
+    "tariq",
+    "theo",
+    "victor",
+    "walter",
+    "zane",
+}
+
+_DEFAULT_TAGS_BY_STEM = {
+    "mixamo_joe_anderson": {"male", "office", "business", "suit", "formal"},
+    "mixamo_james_thompson": {"male", "office", "business", "formal"},
+    "mixamo_steve_johnson": {"male", "casual", "office"},
+    "mixamo_brian_carter": {"male", "casual"},
+    "mixamo_alex_jefferson": {"male", "casual"},
+    "mixamo_roth_miller": {"male", "casual"},
+    "mixamo_chad_thompson": {"male", "casual"},
+    "police": {"male", "police", "uniform", "officer"},
+    "male_1": {"male", "generic"},
+    "mixamo_female_1_decimated": {"female", "generic"},
+}
+
+_PROMPT_SYNONYMS = {
+    "man": {"male"},
+    "male": {"male"},
+    "boy": {"male"},
+    "gentleman": {"male"},
+    "男人": {"male"},
+    "男性": {"male"},
+    "男": {"male"},
+    "woman": {"female"},
+    "female": {"female"},
+    "girl": {"female"},
+    "lady": {"female"},
+    "女士": {"female"},
+    "女人": {"female"},
+    "女性": {"female"},
+    "女": {"female"},
+    "office": {"office", "business"},
+    "business": {"business", "office"},
+    "suit": {"suit", "formal"},
+    "formal": {"formal", "suit"},
+    "worker": {"office"},
+    "西装": {"suit", "formal"},
+    "办公室": {"office", "business"},
+    "商务": {"business", "formal"},
+    "警察": {"police", "officer", "uniform"},
+    "police": {"police", "officer", "uniform"},
+    "officer": {"police", "officer", "uniform"},
+    "uniform": {"uniform"},
+}
+
+
+def _tokenize(text: str) -> set[str]:
+    words = set(re.findall(r"[a-z0-9]+", text.lower()))
+    for phrase, tags in _PROMPT_SYNONYMS.items():
+        if phrase in text.lower():
+            words.update(tags)
+    return words
+
+
+def _display_name_from_stem(stem: str) -> str:
+    clean = stem
+    for prefix in ("mixamo_", "custom_"):
+        if clean.startswith(prefix):
+            clean = clean[len(prefix) :]
+            break
+    clean = clean.replace("_merge", "").replace("_decimated", "")
+    clean = clean.replace("_", " ").replace(".glb", "")
+    return " ".join(part.capitalize() for part in clean.split())
+
+
+@dataclass(frozen=True)
+class AvatarAsset:
+    path: Path
+    display_name: str
+    provider: str
+    tags: set[str] = field(default_factory=set)
+    max_alpha_fraction: float = 0.0
+    alpha_material_count: int = 0
+
+    @property
+    def stem_key(self) -> str:
+        return self.path.stem.lower()
+
+    @property
+    def tokens(self) -> set[str]:
+        return _tokenize(f"{self.display_name} {self.path.stem} {' '.join(sorted(self.tags))}")
+
+
+@dataclass(frozen=True)
+class AvatarMatch:
+    asset: AvatarAsset
+    score: float
+    reasons: tuple[str, ...]
+
+
+def _image_bytes(gltf: GLTF2, image_index: int, glb_path: Path) -> bytes | None:
+    image = gltf.images[image_index]
+    if image.bufferView is not None:
+        view = gltf.bufferViews[image.bufferView]
+        blob = gltf.binary_blob()
+        start = int(view.byteOffset or 0)
+        return bytes(blob[start : start + int(view.byteLength or 0)])
+    if image.uri:
+        if image.uri.startswith("data:"):
+            return base64.b64decode(image.uri.split(",", 1)[1])
+        image_path = glb_path.parent / image.uri
+        if image_path.exists():
+            return image_path.read_bytes()
+    return None
+
+
+def _alpha_profile(path: Path) -> tuple[float, int]:
+    try:
+        gltf = GLTF2().load(str(path))
+    except Exception:
+        return 1.0, 1
+
+    fractions: list[float] = []
+    for material in gltf.materials or []:
+        pbr = material.pbrMetallicRoughness
+        if not pbr or not pbr.baseColorTexture:
+            continue
+        texture = gltf.textures[pbr.baseColorTexture.index]
+        if texture.source is None:
+            continue
+        raw = _image_bytes(gltf, texture.source, path)
+        if not raw:
+            continue
+        try:
+            with Image.open(io.BytesIO(raw)) as image:
+                alpha = np.asarray(image.convert("RGBA"))[:, :, 3]
+                fractions.append(float((alpha < 250).mean()))
+        except Exception:
+            continue
+    return (max(fractions) if fractions else 0.0, sum(fraction > 0.05 for fraction in fractions))
+
+
+def _asset_from_path(path: Path, catalog: dict[str, Any] | None = None) -> AvatarAsset:
+    stem = path.stem.lower()
+    provider = "mixamo" if stem.startswith("mixamo_") else "custom" if stem.startswith("custom_") else "local"
+    display_name = _display_name_from_stem(path.stem)
+    tags = set(_DEFAULT_TAGS_BY_STEM.get(stem, set()))
+    tokens = _tokenize(display_name)
+    if tokens & _FEMALE_NAMES:
+        tags.add("female")
+    if tokens & _MALE_NAMES:
+        tags.add("male")
+    tags.update(tokens - _FEMALE_NAMES - _MALE_NAMES)
+
+    if catalog:
+        override = catalog.get(path.name) or catalog.get(path.stem) or catalog.get(str(path))
+        if isinstance(override, dict):
+            display_name = str(override.get("display_name") or display_name)
+            tags.update(str(tag).lower() for tag in override.get("tags", []))
+            provider = str(override.get("provider") or provider)
+
+    max_alpha, alpha_count = _alpha_profile(path)
+    return AvatarAsset(
+        path=path,
+        display_name=display_name,
+        provider=provider,
+        tags=tags,
+        max_alpha_fraction=max_alpha,
+        alpha_material_count=alpha_count,
+    )
+
+
+def load_avatar_catalog(catalog_path: Path | None) -> dict[str, Any]:
+    if not catalog_path:
+        return {}
+    if not catalog_path.exists():
+        raise FileNotFoundError(f"avatar catalog does not exist: {catalog_path}")
+    data = json.loads(catalog_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"avatar catalog must be a JSON object: {catalog_path}")
+    return data
+
+
+def build_avatar_index(avatar_root: Path, catalog_path: Path | None = None) -> list[AvatarAsset]:
+    catalog = load_avatar_catalog(catalog_path)
+    assets = [_asset_from_path(path, catalog) for path in sorted(avatar_root.glob("*.glb"))]
+    if not assets:
+        raise FileNotFoundError(f"no .glb avatars found under {avatar_root}")
+    return assets
+
+
+def score_avatar(prompt: str, asset: AvatarAsset) -> AvatarMatch:
+    prompt_tokens = _tokenize(prompt)
+    asset_tokens = asset.tokens
+    overlap = prompt_tokens & asset_tokens
+
+    score = float(len(overlap) * 8)
+    reasons: list[str] = []
+    if overlap:
+        reasons.append(f"matched tokens: {', '.join(sorted(overlap)[:8])}")
+
+    display_lower = asset.display_name.lower()
+    if display_lower and display_lower in prompt.lower():
+        score += 80
+        reasons.append(f"explicit name match: {asset.display_name}")
+
+    if "male" in prompt_tokens or "female" in prompt_tokens:
+        wanted = "female" if "female" in prompt_tokens else "male"
+        if wanted in asset.tags:
+            score += 30
+            reasons.append(f"gender tag: {wanted}")
+        elif {"male", "female"} & asset.tags:
+            score -= 25
+
+    for tag in ("police", "office", "business", "suit", "uniform", "formal"):
+        if tag in prompt_tokens and tag in asset.tags:
+            score += 20
+            reasons.append(f"appearance tag: {tag}")
+
+    if asset.provider == "mixamo":
+        score += 8
+        reasons.append("Mixamo/ViCo skeleton compatibility")
+    has_strong_suit_match = bool({"suit", "formal"} & prompt_tokens & asset.tags)
+    if asset.max_alpha_fraction > 0.5 and has_strong_suit_match and asset.alpha_material_count <= 1:
+        score -= 5
+        reasons.append(f"single alpha atlas allowed with solidified shell: {asset.max_alpha_fraction:.2f}")
+    elif asset.max_alpha_fraction > 0.5:
+        score -= 120
+        reasons.append(f"large transparent texture area unsafe for Habitat: {asset.max_alpha_fraction:.2f}")
+    elif asset.max_alpha_fraction > 0.1:
+        score -= 45
+        reasons.append(f"moderate transparent texture area: {asset.max_alpha_fraction:.2f}")
+    elif asset.alpha_material_count == 0:
+        score += 12
+        reasons.append("opaque material profile")
+    if "merge" in asset.path.stem.lower():
+        score -= 6
+    if "decimated" in asset.path.stem.lower():
+        score -= 4
+    if "generic" in asset.tags:
+        score -= 3
+
+    if not reasons:
+        reasons.append("fallback best available humanoid GLB")
+    return AvatarMatch(asset=asset, score=score, reasons=tuple(reasons))
+
+
+def select_avatar(
+    prompt: str,
+    avatar_root: Path,
+    *,
+    preferred_avatar: Path | None = None,
+    catalog_path: Path | None = None,
+) -> tuple[AvatarMatch, list[AvatarMatch]]:
+    if preferred_avatar:
+        asset = _asset_from_path(preferred_avatar, load_avatar_catalog(catalog_path))
+        return AvatarMatch(asset=asset, score=float("inf"), reasons=("explicit avatar path",)), []
+
+    matches = [score_avatar(prompt, asset) for asset in build_avatar_index(avatar_root, catalog_path)]
+    matches.sort(key=lambda item: (item.score, item.asset.provider == "mixamo"), reverse=True)
+    return matches[0], matches[:5]

--- a/src/havln3/gltf_utils.py
+++ b/src/havln3/gltf_utils.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pygltflib import GLTF2
+from scipy.spatial.transform import Rotation
+
+
+_COMPONENT_DTYPES = {
+    5120: np.int8,
+    5121: np.uint8,
+    5122: np.int16,
+    5123: np.uint16,
+    5125: np.uint32,
+    5126: np.float32,
+}
+_TYPE_COUNTS = {
+    "SCALAR": 1,
+    "VEC2": 2,
+    "VEC3": 3,
+    "VEC4": 4,
+    "MAT2": 4,
+    "MAT3": 9,
+    "MAT4": 16,
+}
+
+
+def joint_base_name(name: str | None) -> str:
+    if not name:
+        return ""
+    return name.split(":")[-1].split("|")[-1].strip()
+
+
+def read_accessor(gltf: GLTF2, accessor_index: int | None) -> np.ndarray:
+    if accessor_index is None:
+        raise ValueError("missing accessor index")
+    accessor = gltf.accessors[accessor_index]
+    if accessor.bufferView is None:
+        raise ValueError(f"accessor {accessor_index} has no bufferView")
+    buffer_view = gltf.bufferViews[accessor.bufferView]
+    dtype = np.dtype(_COMPONENT_DTYPES[accessor.componentType]).newbyteorder("<")
+    components = _TYPE_COUNTS[accessor.type]
+    blob = gltf.binary_blob()
+    offset = int(buffer_view.byteOffset or 0) + int(accessor.byteOffset or 0)
+    count = int(accessor.count)
+    stride = int(buffer_view.byteStride or 0)
+
+    if stride and stride != dtype.itemsize * components:
+        rows = []
+        for row_index in range(count):
+            row_offset = offset + row_index * stride
+            rows.append(np.frombuffer(blob, dtype=dtype, count=components, offset=row_offset))
+        array = np.vstack(rows)
+    else:
+        array = np.frombuffer(blob, dtype=dtype, count=count * components, offset=offset)
+        array = array.reshape(count, components)
+
+    if accessor.normalized and np.issubdtype(array.dtype, np.integer):
+        if np.issubdtype(array.dtype, np.signedinteger):
+            max_value = float(np.iinfo(array.dtype).max)
+            array = np.maximum(array.astype(np.float64) / max_value, -1.0)
+        else:
+            max_value = float(np.iinfo(array.dtype).max)
+            array = array.astype(np.float64) / max_value
+    return array.copy()
+
+
+def _node_matrix(node: Any, rotation_delta: np.ndarray | None = None) -> np.ndarray:
+    if node.matrix is not None:
+        matrix = np.asarray(node.matrix, dtype=np.float64).reshape(4, 4).T
+        if rotation_delta is not None:
+            delta = np.eye(4, dtype=np.float64)
+            delta[:3, :3] = Rotation.from_quat(rotation_delta).as_matrix()
+            matrix = matrix @ delta
+        return matrix
+
+    translation = np.asarray(node.translation or [0.0, 0.0, 0.0], dtype=np.float64)
+    rotation = np.asarray(node.rotation or [0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    if rotation_delta is not None:
+        rotation = (Rotation.from_quat(rotation) * Rotation.from_quat(rotation_delta)).as_quat()
+    scale = np.asarray(node.scale or [1.0, 1.0, 1.0], dtype=np.float64)
+
+    matrix = np.eye(4, dtype=np.float64)
+    matrix[:3, :3] = Rotation.from_quat(rotation).as_matrix() @ np.diag(scale)
+    matrix[:3, 3] = translation
+    return matrix
+
+
+def node_global_matrices(gltf: GLTF2, local_joint_deltas: np.ndarray | None = None) -> list[np.ndarray]:
+    skin = gltf.skins[0] if gltf.skins else None
+    joint_to_skin_index = {}
+    if skin is not None:
+        joint_to_skin_index = {joint: index for index, joint in enumerate(skin.joints or [])}
+
+    globals_: list[np.ndarray | None] = [None] * len(gltf.nodes)
+
+    def local_matrix(node_index: int) -> np.ndarray:
+        skin_index = joint_to_skin_index.get(node_index)
+        delta = None
+        if skin_index is not None and local_joint_deltas is not None:
+            delta = local_joint_deltas[skin_index]
+        return _node_matrix(gltf.nodes[node_index], delta)
+
+    def visit(node_index: int, parent: np.ndarray) -> None:
+        current = parent @ local_matrix(node_index)
+        globals_[node_index] = current
+        for child in gltf.nodes[node_index].children or []:
+            visit(child, current)
+
+    scene_indices = gltf.scene
+    scenes = [gltf.scenes[scene_indices]] if scene_indices is not None and gltf.scenes else gltf.scenes or []
+    for scene in scenes:
+        for root in scene.nodes or []:
+            visit(root, np.eye(4, dtype=np.float64))
+    for index, matrix in enumerate(globals_):
+        if matrix is None:
+            visit(index, np.eye(4, dtype=np.float64))
+    return [matrix if matrix is not None else np.eye(4, dtype=np.float64) for matrix in globals_]
+
+
+def deform_skinned_primitives(gltf: GLTF2, local_joint_deltas: np.ndarray) -> list[np.ndarray]:
+    if not gltf.skins:
+        raise ValueError("avatar GLB has no skin")
+    skin = gltf.skins[0]
+    inverse_bind = read_accessor(gltf, skin.inverseBindMatrices)
+    inverse_bind = inverse_bind.reshape((-1, 4, 4)).transpose(0, 2, 1)
+    globals_ = node_global_matrices(gltf, local_joint_deltas)
+    joint_mats = np.stack([globals_[joint] @ inverse_bind[index] for index, joint in enumerate(skin.joints)])
+
+    deformed: list[np.ndarray] = []
+    for mesh in gltf.meshes or []:
+        for primitive in mesh.primitives:
+            positions = read_accessor(gltf, primitive.attributes.POSITION).astype(np.float64)
+            joints_accessor = getattr(primitive.attributes, "JOINTS_0", None)
+            weights_accessor = getattr(primitive.attributes, "WEIGHTS_0", None)
+            if joints_accessor is None or weights_accessor is None:
+                deformed.append(positions)
+                continue
+
+            joints = read_accessor(gltf, joints_accessor).astype(np.int64)
+            weights = read_accessor(gltf, weights_accessor).astype(np.float64)
+            weights = weights / (weights.sum(axis=1, keepdims=True) + 1e-12)
+            homogeneous = np.c_[positions, np.ones(len(positions), dtype=np.float64)]
+            out = np.zeros((len(positions), 4), dtype=np.float64)
+            for weight_index in range(weights.shape[1]):
+                out += weights[:, weight_index : weight_index + 1] * np.einsum(
+                    "nij,nj->ni", joint_mats[joints[:, weight_index]], homogeneous
+                )
+            deformed.append(out[:, :3])
+    return deformed
+
+
+def identity_quaternions(count: int) -> np.ndarray:
+    quats = np.zeros((count, 4), dtype=np.float64)
+    quats[:, 3] = 1.0
+    return quats
+
+
+@dataclass(frozen=True)
+class VertexNormalizer:
+    scale: float
+    source_ground: float
+    target_ground_y: float
+    source_up_axis: int = 2
+
+    @property
+    def _axis_order(self) -> tuple[int, int, int]:
+        if self.source_up_axis == 2:
+            return (0, 2, 1)
+        if self.source_up_axis == 1:
+            return (0, 1, 2)
+        return (1, 0, 2)
+
+    @classmethod
+    def from_vertices(
+        cls,
+        vertices_by_primitive: list[np.ndarray],
+        *,
+        target_height: float,
+        ground_y: float,
+        source_up_axis: int = 2,
+    ) -> "VertexNormalizer":
+        combined = np.vstack(vertices_by_primitive)
+        source_ground = float(combined[:, source_up_axis].min())
+        source_top = float(combined[:, source_up_axis].max())
+        height = max(source_top - source_ground, 1e-9)
+        return cls(
+            scale=float(target_height) / height,
+            source_ground=source_ground,
+            target_ground_y=ground_y,
+            source_up_axis=source_up_axis,
+        )
+
+    def _to_target_axes(self, values: np.ndarray) -> np.ndarray:
+        out = values[:, self._axis_order].copy()
+        out[:, 1] -= self.source_ground
+        out *= self.scale
+        out[:, 1] += self.target_ground_y
+        return out
+
+    def transform(
+        self,
+        vertices_by_primitive: list[np.ndarray],
+        points: np.ndarray | None = None,
+        *,
+        root_offset: np.ndarray | None = None,
+        snap_to_ground: bool = True,
+    ) -> tuple[list[np.ndarray], np.ndarray | None]:
+        transformed = [self._to_target_axes(vertices) for vertices in vertices_by_primitive]
+
+        transformed_points = None
+        if points is not None:
+            transformed_points = self._to_target_axes(points)
+
+        if root_offset is not None:
+            root = np.asarray(root_offset, dtype=np.float64)
+            transformed = [vertices + root for vertices in transformed]
+            if transformed_points is not None:
+                transformed_points = transformed_points + root
+
+        if snap_to_ground:
+            lowest = min(float(vertices[:, 1].min()) for vertices in transformed)
+            if lowest < self.target_ground_y:
+                lift = self.target_ground_y - lowest
+                transformed = [vertices + np.array([0.0, lift, 0.0]) for vertices in transformed]
+                if transformed_points is not None:
+                    transformed_points = transformed_points + np.array([0.0, lift, 0.0])
+
+        return transformed, transformed_points
+
+
+def write_object_config(path: Path, glb_path: Path) -> None:
+    config = {
+        "render_asset": glb_path.name,
+        "collision_asset": glb_path.name,
+        "scale": [1.0, 1.0, 1.0],
+        "use_mesh_for_collision": True,
+        "requires_lighting": True,
+        "mass": 1.0,
+        "margin": 0.0,
+    }
+    path.write_text(json.dumps(config, indent=2), encoding="utf-8")

--- a/src/havln3/materials.py
+++ b/src/havln3/materials.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from pygltflib import GLTF2
+
+
+_ALPHA_KEYWORDS = ("hair", "lash", "eyelash", "brow")
+
+
+def _image_bytes(gltf: GLTF2, image_index: int, glb_path: Path) -> bytes | None:
+    image = gltf.images[image_index]
+    if image.bufferView is not None:
+        view = gltf.bufferViews[image.bufferView]
+        blob = gltf.binary_blob()
+        start = int(view.byteOffset or 0)
+        end = start + int(view.byteLength or 0)
+        return bytes(blob[start:end])
+    if image.uri:
+        if image.uri.startswith("data:"):
+            _, encoded = image.uri.split(",", 1)
+            return base64.b64decode(encoded)
+        image_path = (glb_path.parent / image.uri).resolve()
+        if image_path.exists():
+            return image_path.read_bytes()
+    return None
+
+
+def _base_color_has_alpha(gltf: GLTF2, material: Any, glb_path: Path) -> bool:
+    pbr = material.pbrMetallicRoughness
+    if not pbr or not pbr.baseColorTexture:
+        return False
+    texture = gltf.textures[pbr.baseColorTexture.index]
+    if texture.source is None:
+        return False
+    raw = _image_bytes(gltf, texture.source, glb_path)
+    if not raw:
+        return False
+    try:
+        with Image.open(io.BytesIO(raw)) as image:
+            if image.mode not in {"RGBA", "LA"} and "transparency" not in image.info:
+                return False
+            alpha = np.asarray(image.convert("RGBA"))[:, :, 3]
+            return float((alpha < 250).mean()) > 0.01
+    except Exception:
+        return False
+
+
+def fix_habitat_materials(
+    glb_path: Path,
+    *,
+    alpha_cutoff: float = 0.55,
+    roughness: float = 0.88,
+    detect_texture_alpha: bool = True,
+) -> list[dict[str, object]]:
+    """Make exported avatar frames friendlier to Habitat/ViCo rendering.
+
+    The fix preserves original UVs and base-color textures. It changes only
+    render-state metadata that commonly causes transparent hair cards to sort
+    badly in Habitat. Exported animation frames are always marked double-sided
+    because Habitat side/back camera views can otherwise make single-surface
+    clothing read as a flat paper cutout.
+    """
+
+    gltf = GLTF2().load(str(glb_path))
+    changes: list[dict[str, object]] = []
+    for index, material in enumerate(gltf.materials or []):
+        name = material.name or f"material_{index}"
+        lower = name.lower()
+        pbr = material.pbrMetallicRoughness
+        before = {
+            "name": name,
+            "alphaMode": material.alphaMode,
+            "alphaCutoff": material.alphaCutoff,
+            "doubleSided": material.doubleSided,
+            "metallicFactor": pbr.metallicFactor if pbr else None,
+            "roughnessFactor": pbr.roughnessFactor if pbr else None,
+        }
+
+        if pbr is not None:
+            pbr.metallicFactor = 0.0
+            pbr.roughnessFactor = max(float(pbr.roughnessFactor or 0.0), roughness)
+            pbr.metallicRoughnessTexture = None
+
+        alpha_like = any(keyword in lower for keyword in _ALPHA_KEYWORDS)
+        if detect_texture_alpha and not alpha_like:
+            alpha_like = material.alphaMode == "BLEND" or _base_color_has_alpha(gltf, material, glb_path)
+        if alpha_like:
+            material.alphaMode = "MASK"
+            material.alphaCutoff = alpha_cutoff
+        else:
+            material.alphaMode = "OPAQUE"
+            material.alphaCutoff = None
+            if pbr is not None and pbr.baseColorFactor and len(pbr.baseColorFactor) >= 4:
+                pbr.baseColorFactor[3] = 1.0
+        material.doubleSided = True
+
+        after = {
+            "name": name,
+            "alphaMode": material.alphaMode,
+            "alphaCutoff": material.alphaCutoff,
+            "doubleSided": material.doubleSided,
+            "metallicFactor": pbr.metallicFactor if pbr else None,
+            "roughnessFactor": pbr.roughnessFactor if pbr else None,
+        }
+        if after != before:
+            changes.append({"material_index": index, "before": before, "after": after})
+
+    if changes:
+        gltf.save_binary(str(glb_path))
+    return changes

--- a/src/havln3/motion.py
+++ b/src/havln3/motion.py
@@ -46,6 +46,7 @@ class MotionClip:
     source_path: Path
     prompt: str | None = None
     fps: float | None = None
+    global_rot_mats: np.ndarray | None = None
 
     @property
     def frames(self) -> int:
@@ -108,6 +109,7 @@ def load_motion_file(
             foot_contacts=data["foot_contacts"].astype(bool) if "foot_contacts" in data else None,
             source_path=motion_path,
             fps=fps,
+            global_rot_mats=data["global_rot_mats"].astype(np.float64) if "global_rot_mats" in data else None,
         )
 
     if "root_orient" in data and "pose_body" in data:
@@ -118,6 +120,7 @@ def load_motion_file(
             foot_contacts=data["foot_contacts"].astype(bool) if "foot_contacts" in data else None,
             source_path=motion_path,
             fps=float(data["mocap_frame_rate"]) if "mocap_frame_rate" in data else None,
+            global_rot_mats=None,
         )
 
     if amass_path:
@@ -165,6 +168,9 @@ def resample_motion(clip: MotionClip, target_frames: int) -> MotionClip:
         source_path=clip.source_path,
         prompt=clip.prompt,
         fps=clip.fps,
+        global_rot_mats=_resample_rotations(clip.global_rot_mats, target_frames)
+        if clip.global_rot_mats is not None
+        else None,
     )
 
 

--- a/src/havln3/motion.py
+++ b/src/havln3/motion.py
@@ -42,6 +42,7 @@ class MotionClip:
     local_rot_mats: np.ndarray
     root_positions: np.ndarray | None
     posed_joints: np.ndarray | None
+    foot_contacts: np.ndarray | None
     source_path: Path
     prompt: str | None = None
     fps: float | None = None
@@ -77,7 +78,14 @@ def _load_torch_smpl_params(path: Path, param_group: str = "body_params_global")
     if isinstance(segment_info, list) and segment_info:
         prompt = segment_info[0].get("caption")
     mats = _rotvecs_to_mats(global_orient, body_pose)
-    return MotionClip(local_rot_mats=mats, root_positions=root_positions, posed_joints=None, source_path=path, prompt=prompt)
+    return MotionClip(
+        local_rot_mats=mats,
+        root_positions=root_positions,
+        posed_joints=None,
+        foot_contacts=None,
+        source_path=path,
+        prompt=prompt,
+    )
 
 
 def load_motion_file(
@@ -97,6 +105,7 @@ def load_motion_file(
             local_rot_mats=data["local_rot_mats"].astype(np.float64),
             root_positions=None if root is None else root.astype(np.float64),
             posed_joints=data["posed_joints"].astype(np.float64) if "posed_joints" in data else None,
+            foot_contacts=data["foot_contacts"].astype(bool) if "foot_contacts" in data else None,
             source_path=motion_path,
             fps=fps,
         )
@@ -106,6 +115,7 @@ def load_motion_file(
             local_rot_mats=_rotvecs_to_mats(data["root_orient"], data["pose_body"]),
             root_positions=data["trans"].astype(np.float64) if "trans" in data else None,
             posed_joints=None,
+            foot_contacts=data["foot_contacts"].astype(bool) if "foot_contacts" in data else None,
             source_path=motion_path,
             fps=float(data["mocap_frame_rate"]) if "mocap_frame_rate" in data else None,
         )
@@ -139,11 +149,19 @@ def _resample_rotations(mats: np.ndarray, target_frames: int) -> np.ndarray:
     return out
 
 
+def _resample_contacts(values: np.ndarray | None, target_frames: int) -> np.ndarray | None:
+    if values is None or len(values) == target_frames:
+        return values
+    indices = np.rint(np.linspace(0, len(values) - 1, target_frames)).astype(np.int64)
+    return values[indices].astype(bool)
+
+
 def resample_motion(clip: MotionClip, target_frames: int) -> MotionClip:
     return MotionClip(
         local_rot_mats=_resample_rotations(clip.local_rot_mats, target_frames),
         root_positions=_resample_array(clip.root_positions, target_frames),
         posed_joints=_resample_array(clip.posed_joints, target_frames),
+        foot_contacts=_resample_contacts(clip.foot_contacts, target_frames),
         source_path=clip.source_path,
         prompt=clip.prompt,
         fps=clip.fps,

--- a/src/havln3/motion.py
+++ b/src/havln3/motion.py
@@ -246,10 +246,19 @@ def generate_kimodo_motion_candidates(
 
 
 def _generated_motion_candidates(output_stem: Path) -> list[tuple[Path, Path | None]]:
-    candidates = sorted(output_stem.parent.glob(f"{output_stem.name}*.npz"))
+    candidates: list[Path] = []
+
+    def append_unique(paths: list[Path]) -> None:
+        for path in paths:
+            if path.exists() and path not in candidates:
+                candidates.append(path)
+
     direct = output_stem.with_suffix(".npz")
-    if direct.exists() and direct not in candidates:
-        candidates.insert(0, direct)
+    append_unique([direct])
+    append_unique(sorted(output_stem.parent.glob(f"{output_stem.name}*.npz")))
+    append_unique(sorted((output_stem.parent / output_stem.name).glob(f"{output_stem.name}*.npz")))
+    if output_stem.is_dir():
+        append_unique(sorted(output_stem.glob(f"{output_stem.name}*.npz")))
     if not candidates:
         return []
 
@@ -258,10 +267,13 @@ def _generated_motion_candidates(output_stem: Path) -> list[tuple[Path, Path | N
         suffix = motion_path.stem.removeprefix(output_stem.name).lstrip("_")
         companion_names = [
             motion_path.with_name(motion_path.stem + "_amass.npz"),
+            motion_path.parent / f"amass_{suffix}.npz" if suffix else None,
             output_stem.with_name(output_stem.name + "_amass.npz"),
         ]
         if suffix:
             companion_names.append(output_stem.with_name(f"amass_{suffix}.npz"))
-        amass_path = next((path for path in companion_names if path.exists()), None)
+            companion_names.append(output_stem / f"amass_{suffix}.npz")
+        companion_names.append(output_stem / f"{output_stem.name}_amass.npz")
+        amass_path = next((path for path in companion_names if path and path.exists()), None)
         result.append((motion_path, amass_path))
     return result

--- a/src/havln3/motion.py
+++ b/src/havln3/motion.py
@@ -184,7 +184,38 @@ def generate_kimodo_motion(
     seed: int | None = None,
     cfg_type: str | None = None,
     extra_args: list[str] | None = None,
+    num_samples: int = 1,
 ) -> tuple[Path, Path | None]:
+    candidates = generate_kimodo_motion_candidates(
+        prompt,
+        output_stem,
+        model=model,
+        duration=duration,
+        kimodo_bin=kimodo_bin,
+        seed=seed,
+        cfg_type=cfg_type,
+        extra_args=extra_args,
+        num_samples=num_samples,
+    )
+    if candidates:
+        return candidates[0]
+    motion_path = output_stem.with_suffix(".npz")
+    amass_path = output_stem.with_name(output_stem.name + "_amass.npz")
+    return motion_path, amass_path if amass_path.exists() else None
+
+
+def generate_kimodo_motion_candidates(
+    prompt: str,
+    output_stem: Path,
+    *,
+    model: str = "Kimodo-SMPLX-RP-v1",
+    duration: float = 5.0,
+    kimodo_bin: str = "kimodo_gen",
+    seed: int | None = None,
+    cfg_type: str | None = None,
+    extra_args: list[str] | None = None,
+    num_samples: int = 1,
+) -> list[tuple[Path, Path | None]]:
     executable = shutil.which(kimodo_bin)
     if not executable:
         raise RuntimeError(
@@ -201,7 +232,7 @@ def generate_kimodo_motion(
         "--output",
         str(output_stem),
         "--num_samples",
-        "1",
+        str(max(1, num_samples)),
     ]
     if seed is not None:
         command.extend(["--seed", str(seed)])
@@ -211,10 +242,26 @@ def generate_kimodo_motion(
         command.extend(extra_args)
     subprocess.run(command, check=True)
 
-    motion_path = output_stem.with_suffix(".npz")
-    amass_path = output_stem.with_name(output_stem.name + "_amass.npz")
-    if not motion_path.exists():
-        candidates = sorted(output_stem.parent.glob(f"{output_stem.name}*.npz"))
-        if candidates:
-            motion_path = candidates[0]
-    return motion_path, amass_path if amass_path.exists() else None
+    return _generated_motion_candidates(output_stem)
+
+
+def _generated_motion_candidates(output_stem: Path) -> list[tuple[Path, Path | None]]:
+    candidates = sorted(output_stem.parent.glob(f"{output_stem.name}*.npz"))
+    direct = output_stem.with_suffix(".npz")
+    if direct.exists() and direct not in candidates:
+        candidates.insert(0, direct)
+    if not candidates:
+        return []
+
+    result: list[tuple[Path, Path | None]] = []
+    for motion_path in candidates:
+        suffix = motion_path.stem.removeprefix(output_stem.name).lstrip("_")
+        companion_names = [
+            motion_path.with_name(motion_path.stem + "_amass.npz"),
+            output_stem.with_name(output_stem.name + "_amass.npz"),
+        ]
+        if suffix:
+            companion_names.append(output_stem.with_name(f"amass_{suffix}.npz"))
+        amass_path = next((path for path in companion_names if path.exists()), None)
+        result.append((motion_path, amass_path))
+    return result

--- a/src/havln3/motion.py
+++ b/src/havln3/motion.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from scipy.spatial.transform import Rotation, Slerp
+
+
+SMPL22_JOINT_NAMES = (
+    "Hips",
+    "LeftUpLeg",
+    "RightUpLeg",
+    "Spine",
+    "LeftLeg",
+    "RightLeg",
+    "Spine1",
+    "LeftFoot",
+    "RightFoot",
+    "Spine2",
+    "LeftToeBase",
+    "RightToeBase",
+    "Neck",
+    "LeftShoulder",
+    "RightShoulder",
+    "Head",
+    "LeftArm",
+    "RightArm",
+    "LeftForeArm",
+    "RightForeArm",
+    "LeftHand",
+    "RightHand",
+)
+
+SMPL22_TO_MIXAMO = {index: name for index, name in enumerate(SMPL22_JOINT_NAMES)}
+
+
+@dataclass(frozen=True)
+class MotionClip:
+    local_rot_mats: np.ndarray
+    root_positions: np.ndarray | None
+    posed_joints: np.ndarray | None
+    source_path: Path
+    prompt: str | None = None
+    fps: float | None = None
+
+    @property
+    def frames(self) -> int:
+        return int(self.local_rot_mats.shape[0])
+
+
+def _rotvecs_to_mats(root_orient: np.ndarray, pose_body: np.ndarray) -> np.ndarray:
+    frames = int(root_orient.shape[0])
+    mats = np.tile(np.eye(3, dtype=np.float64), (frames, 22, 1, 1))
+    mats[:, 0] = Rotation.from_rotvec(root_orient.reshape(frames, 3)).as_matrix()
+    body = pose_body.reshape(frames, 21, 3)
+    mats[:, 1:22] = Rotation.from_rotvec(body.reshape(-1, 3)).as_matrix().reshape(frames, 21, 3, 3)
+    return mats
+
+
+def _load_torch_smpl_params(path: Path, param_group: str = "body_params_global") -> MotionClip:
+    import torch
+
+    params = torch.load(path, map_location="cpu")
+    source = params[param_group]
+    body_pose = source["body_pose"].detach().float().cpu().numpy()
+    global_orient = source["global_orient"].detach().float().cpu().numpy()
+    root_positions = None
+    for key in ("transl", "trans", "translation"):
+        if key in source:
+            root_positions = source[key].detach().float().cpu().numpy()
+            break
+    prompt = None
+    segment_info = params.get("segment_info")
+    if isinstance(segment_info, list) and segment_info:
+        prompt = segment_info[0].get("caption")
+    mats = _rotvecs_to_mats(global_orient, body_pose)
+    return MotionClip(local_rot_mats=mats, root_positions=root_positions, posed_joints=None, source_path=path, prompt=prompt)
+
+
+def load_motion_file(
+    motion_path: Path,
+    *,
+    amass_path: Path | None = None,
+    gem_param_group: str = "body_params_global",
+) -> MotionClip:
+    if motion_path.suffix == ".pt":
+        return _load_torch_smpl_params(motion_path, gem_param_group)
+
+    data = np.load(motion_path, allow_pickle=True)
+    if "local_rot_mats" in data:
+        fps = float(data["fps"]) if "fps" in data else None
+        root = data["smooth_root_pos"] if "smooth_root_pos" in data else data.get("root_positions")
+        return MotionClip(
+            local_rot_mats=data["local_rot_mats"].astype(np.float64),
+            root_positions=None if root is None else root.astype(np.float64),
+            posed_joints=data["posed_joints"].astype(np.float64) if "posed_joints" in data else None,
+            source_path=motion_path,
+            fps=fps,
+        )
+
+    if "root_orient" in data and "pose_body" in data:
+        return MotionClip(
+            local_rot_mats=_rotvecs_to_mats(data["root_orient"], data["pose_body"]),
+            root_positions=data["trans"].astype(np.float64) if "trans" in data else None,
+            posed_joints=None,
+            source_path=motion_path,
+            fps=float(data["mocap_frame_rate"]) if "mocap_frame_rate" in data else None,
+        )
+
+    if amass_path:
+        return load_motion_file(amass_path, gem_param_group=gem_param_group)
+    raise ValueError(f"unsupported motion file format: {motion_path}")
+
+
+def _resample_array(values: np.ndarray | None, target_frames: int) -> np.ndarray | None:
+    if values is None or len(values) == target_frames:
+        return values
+    src_t = np.linspace(0.0, 1.0, len(values))
+    dst_t = np.linspace(0.0, 1.0, target_frames)
+    flat = values.reshape(len(values), -1)
+    out = np.empty((target_frames, flat.shape[1]), dtype=np.float64)
+    for channel in range(flat.shape[1]):
+        out[:, channel] = np.interp(dst_t, src_t, flat[:, channel])
+    return out.reshape((target_frames,) + values.shape[1:])
+
+
+def _resample_rotations(mats: np.ndarray, target_frames: int) -> np.ndarray:
+    if len(mats) == target_frames:
+        return mats
+    src_t = np.linspace(0.0, 1.0, len(mats))
+    dst_t = np.linspace(0.0, 1.0, target_frames)
+    out = np.empty((target_frames,) + mats.shape[1:], dtype=np.float64)
+    for joint_index in range(mats.shape[1]):
+        rotations = Rotation.from_matrix(mats[:, joint_index])
+        out[:, joint_index] = Slerp(src_t, rotations)(dst_t).as_matrix()
+    return out
+
+
+def resample_motion(clip: MotionClip, target_frames: int) -> MotionClip:
+    return MotionClip(
+        local_rot_mats=_resample_rotations(clip.local_rot_mats, target_frames),
+        root_positions=_resample_array(clip.root_positions, target_frames),
+        posed_joints=_resample_array(clip.posed_joints, target_frames),
+        source_path=clip.source_path,
+        prompt=clip.prompt,
+        fps=clip.fps,
+    )
+
+
+def generate_kimodo_motion(
+    prompt: str,
+    output_stem: Path,
+    *,
+    model: str = "Kimodo-SMPLX-RP-v1",
+    duration: float = 5.0,
+    kimodo_bin: str = "kimodo_gen",
+    seed: int | None = None,
+    cfg_type: str | None = None,
+    extra_args: list[str] | None = None,
+) -> tuple[Path, Path | None]:
+    executable = shutil.which(kimodo_bin)
+    if not executable:
+        raise RuntimeError(
+            f"{kimodo_bin!r} was not found. Install Kimodo or pass --motion-npz to retarget an existing output."
+        )
+    output_stem.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        executable,
+        prompt,
+        "--model",
+        model,
+        "--duration",
+        str(duration),
+        "--output",
+        str(output_stem),
+        "--num_samples",
+        "1",
+    ]
+    if seed is not None:
+        command.extend(["--seed", str(seed)])
+    if cfg_type:
+        command.extend(["--cfg_type", cfg_type])
+    if extra_args:
+        command.extend(extra_args)
+    subprocess.run(command, check=True)
+
+    motion_path = output_stem.with_suffix(".npz")
+    amass_path = output_stem.with_name(output_stem.name + "_amass.npz")
+    if not motion_path.exists():
+        candidates = sorted(output_stem.parent.glob(f"{output_stem.name}*.npz"))
+        if candidates:
+            motion_path = candidates[0]
+    return motion_path, amass_path if amass_path.exists() else None

--- a/src/havln3/motion_quality.py
+++ b/src/havln3/motion_quality.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from havln3.motion import MotionClip, load_motion_file, resample_motion
+
+
+SMPL_LEG_JOINTS = {
+    "Left": {"hip": 1, "knee": 4, "ankle": 7, "toe": 10},
+    "Right": {"hip": 2, "knee": 5, "ankle": 8, "toe": 11},
+}
+
+
+@dataclass(frozen=True)
+class MotionQualityOptions:
+    frames: int = 60
+    min_score: float = 62.0
+    min_backflip_rotation_degrees: float = 280.0
+    min_backflip_total_degrees: float = 240.0
+    max_leg_direction_acceleration: float = 0.52
+    max_leg_direction_velocity: float = 1.65
+    min_leg_reach_ratio: float = 0.22
+    min_knee_angle_degrees: float = 22.0
+    min_foot_head_distance_ratio: float = 0.11
+    max_root_drift_ratio: float = 1.15
+
+
+@dataclass(frozen=True)
+class MotionQualityReport:
+    path: str
+    score: float
+    passed: bool
+    reasons: list[str]
+    metrics: dict[str, float | int | bool | str | None]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "score": self.score,
+            "passed": self.passed,
+            "reasons": self.reasons,
+            "metrics": self.metrics,
+        }
+
+
+def _source_to_quality_axes(points: np.ndarray) -> np.ndarray:
+    return points[:, [0, 2, 1]]
+
+
+def _safe_unit(vector: np.ndarray) -> np.ndarray | None:
+    norm = float(np.linalg.norm(vector))
+    if norm < 1e-8:
+        return None
+    return vector / norm
+
+
+def _projected_unit(vector: np.ndarray, normal: np.ndarray) -> np.ndarray | None:
+    projected = vector - normal * float(np.dot(vector, normal))
+    return _safe_unit(projected)
+
+
+def _orthonormal_body_basis(points: np.ndarray) -> np.ndarray | None:
+    if len(points) <= 3:
+        return None
+    hips = points[0]
+    side = _safe_unit(points[SMPL_LEG_JOINTS["Right"]["hip"]] - points[SMPL_LEG_JOINTS["Left"]["hip"]])
+    if side is None:
+        return None
+    for spine_index in (9, 6, 3, 15):
+        if spine_index >= len(points):
+            continue
+        up = _projected_unit(points[spine_index] - hips, side)
+        if up is None:
+            continue
+        forward = _safe_unit(np.cross(side, up))
+        if forward is None:
+            continue
+        up = _safe_unit(np.cross(forward, side))
+        if up is None:
+            continue
+        return np.column_stack([side, up, forward])
+    return None
+
+
+def _angle_degrees(a: np.ndarray, b: np.ndarray) -> float | None:
+    a_unit = _safe_unit(a)
+    b_unit = _safe_unit(b)
+    if a_unit is None or b_unit is None:
+        return None
+    return float(np.degrees(np.arccos(np.clip(float(np.dot(a_unit, b_unit)), -1.0, 1.0))))
+
+
+def _is_backflip_prompt(prompt: str | None) -> bool:
+    text = (prompt or "").lower()
+    return "backflip" in text or "back flip" in text or "后空翻" in text
+
+
+def _is_stationary_prompt(prompt: str | None) -> bool:
+    text = (prompt or "").lower()
+    return any(token in text for token in ("standing", "stationary", "in place", "原地"))
+
+
+def _finite_or_default(value: float | None, default: float = 0.0) -> float:
+    if value is None or not np.isfinite(value):
+        return default
+    return float(value)
+
+
+def _penalize_above(value: float, limit: float, scale: float) -> float:
+    return max(0.0, value - limit) * scale
+
+
+def _penalize_below(value: float, limit: float, scale: float) -> float:
+    return max(0.0, limit - value) * scale
+
+
+def _motion_points(clip: MotionClip, frames: int) -> np.ndarray | None:
+    if clip.posed_joints is None:
+        return None
+    sampled = resample_motion(clip, frames)
+    if sampled.posed_joints is None:
+        return None
+    return np.asarray([_source_to_quality_axes(frame) for frame in sampled.posed_joints], dtype=np.float64)
+
+
+def _body_height(points: np.ndarray) -> float:
+    extents = np.nanmax(points, axis=1) - np.nanmin(points, axis=1)
+    heights = np.linalg.norm(extents, axis=1)
+    return max(float(np.nanmedian(heights)), 1e-6)
+
+
+def _backflip_metrics(points: np.ndarray) -> dict[str, float]:
+    first_basis = _orthonormal_body_basis(points[0])
+    if first_basis is None:
+        return {
+            "backflip_rotation_span_degrees": 0.0,
+            "backflip_total_degrees": 0.0,
+            "backflip_direction_consistency": 0.0,
+            "upside_down_dot": 1.0,
+            "final_upright_dot": 0.0,
+        }
+    up0 = first_basis[:, 1]
+    forward0 = first_basis[:, 2]
+    angles: list[float] = []
+    up_dots: list[float] = []
+    for frame in points:
+        up = _safe_unit(frame[15] - frame[0])
+        if up is None:
+            continue
+        up_dots.append(float(np.dot(up, up0)))
+        angles.append(float(np.arctan2(np.dot(up, forward0), np.dot(up, up0))))
+    if len(angles) < 2:
+        return {
+            "backflip_rotation_span_degrees": 0.0,
+            "backflip_total_degrees": 0.0,
+            "backflip_direction_consistency": 0.0,
+            "upside_down_dot": 1.0,
+            "final_upright_dot": 0.0,
+        }
+    unwrapped = np.unwrap(np.asarray(angles, dtype=np.float64))
+    total = float(np.degrees(unwrapped[-1] - unwrapped[0]))
+    span = float(np.degrees(np.nanmax(unwrapped) - np.nanmin(unwrapped)))
+    direction = np.sign(total) if abs(total) > 1e-6 else 1.0
+    deltas = np.diff(unwrapped) * direction
+    consistency = float(np.mean(deltas > -0.08)) if len(deltas) else 0.0
+    return {
+        "backflip_rotation_span_degrees": span,
+        "backflip_total_degrees": abs(total),
+        "backflip_direction_consistency": consistency,
+        "upside_down_dot": float(np.nanmin(up_dots)) if up_dots else 1.0,
+        "final_upright_dot": float(up_dots[-1]) if up_dots else 0.0,
+    }
+
+
+def _leg_metrics(points: np.ndarray, body_height: float) -> dict[str, float]:
+    frame_count = len(points)
+    local_dirs = np.full((frame_count, 2, 3), np.nan, dtype=np.float64)
+    reach_ratios = np.full((frame_count, 2), np.nan, dtype=np.float64)
+    knee_angles: list[float] = []
+    foot_head_distances: list[float] = []
+    asymmetry: list[float] = []
+
+    for frame_index, frame in enumerate(points):
+        basis = _orthonormal_body_basis(frame)
+        if basis is None:
+            continue
+        mirrored_dirs: list[np.ndarray] = []
+        for side_index, side in enumerate(("Left", "Right")):
+            joints = SMPL_LEG_JOINTS[side]
+            hip = frame[joints["hip"]]
+            knee = frame[joints["knee"]]
+            ankle = frame[joints["ankle"]]
+            toe = frame[joints["toe"]]
+            direction = _safe_unit(ankle - hip)
+            upper_len = float(np.linalg.norm(knee - hip))
+            lower_len = float(np.linalg.norm(ankle - knee))
+            chain_len = upper_len + lower_len
+            if direction is not None:
+                local_direction = _safe_unit(basis.T @ direction)
+                if local_direction is not None:
+                    local_dirs[frame_index, side_index] = local_direction
+                    mirrored = local_direction.copy()
+                    if side == "Right":
+                        mirrored[0] *= -1.0
+                    mirrored_dirs.append(mirrored)
+            if chain_len > 1e-8:
+                reach_ratios[frame_index, side_index] = float(np.linalg.norm(ankle - hip) / chain_len)
+            knee_angle = _angle_degrees(hip - knee, ankle - knee)
+            if knee_angle is not None:
+                knee_angles.append(knee_angle)
+            head = frame[15]
+            foot_head_distances.extend(
+                [
+                    float(np.linalg.norm(ankle - head) / body_height),
+                    float(np.linalg.norm(toe - head) / body_height),
+                ]
+            )
+        if len(mirrored_dirs) == 2:
+            asymmetry.append(float(np.linalg.norm(mirrored_dirs[0] - mirrored_dirs[1])))
+
+    valid_dirs = np.nan_to_num(local_dirs, nan=0.0)
+    direction_velocity = np.diff(valid_dirs, axis=0).reshape(max(frame_count - 1, 0), -1)
+    direction_acceleration = np.diff(valid_dirs, n=2, axis=0).reshape(max(frame_count - 2, 0), -1)
+    return {
+        "leg_direction_velocity_max": float(np.nanmax(np.linalg.norm(direction_velocity, axis=1)))
+        if len(direction_velocity)
+        else 0.0,
+        "leg_direction_acceleration_mean": float(np.nanmean(np.linalg.norm(direction_acceleration, axis=1)))
+        if len(direction_acceleration)
+        else 0.0,
+        "leg_reach_ratio_min": float(np.nanmin(reach_ratios)) if not np.isnan(reach_ratios).all() else 0.0,
+        "knee_angle_min_degrees": float(np.nanmin(knee_angles)) if knee_angles else 0.0,
+        "foot_head_distance_min_ratio": float(np.nanmin(foot_head_distances)) if foot_head_distances else 0.0,
+        "leg_asymmetry_mean": float(np.nanmean(asymmetry)) if asymmetry else 0.0,
+    }
+
+
+def _shape_jerk(points: np.ndarray, body_height: float) -> float:
+    local = points - points[:, :1]
+    acceleration = np.diff(local, n=2, axis=0)
+    if len(acceleration) == 0:
+        return 0.0
+    return float(np.nanmean(np.linalg.norm(acceleration.reshape(len(acceleration), -1), axis=1)) / body_height)
+
+
+def _root_drift_ratio(clip: MotionClip, frames: int, body_height: float) -> float:
+    if clip.root_positions is None:
+        return 0.0
+    root = resample_motion(clip, frames).root_positions
+    if root is None or len(root) < 2:
+        return 0.0
+    horizontal = root[:, [0, 1]]
+    drift = float(np.linalg.norm(horizontal[-1] - horizontal[0]))
+    return drift / body_height
+
+
+def score_motion_clip(
+    clip: MotionClip,
+    *,
+    prompt: str | None = None,
+    options: MotionQualityOptions | None = None,
+) -> MotionQualityReport:
+    options = options or MotionQualityOptions()
+    points = _motion_points(clip, options.frames)
+    reasons: list[str] = []
+    if points is None:
+        return MotionQualityReport(
+            path=str(clip.source_path),
+            score=0.0,
+            passed=False,
+            reasons=["missing posed_joints; cannot evaluate Kimodo skeleton quality"],
+            metrics={"has_posed_joints": False},
+        )
+    finite_ratio = float(np.isfinite(points).mean())
+    body_height = _body_height(points)
+    metrics: dict[str, float | int | bool | str | None] = {
+        "has_posed_joints": True,
+        "finite_ratio": finite_ratio,
+        "body_height": body_height,
+        "frames": int(options.frames),
+    }
+    metrics.update(_backflip_metrics(points))
+    metrics.update(_leg_metrics(points, body_height))
+    metrics["shape_jerk"] = _shape_jerk(points, body_height)
+    metrics["root_drift_ratio"] = _root_drift_ratio(clip, options.frames, body_height)
+
+    score = 100.0
+    if finite_ratio < 0.999:
+        score -= (0.999 - finite_ratio) * 250.0
+        reasons.append("non-finite joint values")
+
+    score -= _penalize_above(
+        float(metrics["shape_jerk"]),
+        0.12,
+        65.0,
+    )
+    score -= _penalize_above(
+        float(metrics["leg_direction_acceleration_mean"]),
+        options.max_leg_direction_acceleration,
+        26.0,
+    )
+    score -= _penalize_above(
+        float(metrics["leg_direction_velocity_max"]),
+        options.max_leg_direction_velocity,
+        16.0,
+    )
+    score -= _penalize_below(
+        float(metrics["leg_reach_ratio_min"]),
+        options.min_leg_reach_ratio,
+        80.0,
+    )
+    score -= _penalize_below(
+        float(metrics["knee_angle_min_degrees"]),
+        options.min_knee_angle_degrees,
+        0.85,
+    )
+    score -= _penalize_below(
+        float(metrics["foot_head_distance_min_ratio"]),
+        options.min_foot_head_distance_ratio,
+        115.0,
+    )
+    score -= _penalize_above(float(metrics["leg_asymmetry_mean"]), 0.62, 14.0)
+
+    if _is_backflip_prompt(prompt or clip.prompt):
+        span = float(metrics["backflip_rotation_span_degrees"])
+        total = float(metrics["backflip_total_degrees"])
+        consistency = float(metrics["backflip_direction_consistency"])
+        upside_down_dot = float(metrics["upside_down_dot"])
+        final_upright_dot = float(metrics["final_upright_dot"])
+        if span < options.min_backflip_rotation_degrees:
+            score -= (options.min_backflip_rotation_degrees - span) * 0.18
+            reasons.append("backflip rotation span is too small")
+        if total < options.min_backflip_total_degrees:
+            score -= (options.min_backflip_total_degrees - total) * 0.14
+            reasons.append("backflip does not complete enough net rotation")
+        if consistency < 0.58:
+            score -= (0.58 - consistency) * 28.0
+            reasons.append("backflip direction is inconsistent")
+        if upside_down_dot > -0.35:
+            score -= (upside_down_dot + 0.35) * 24.0
+            reasons.append("motion never reaches a clear inverted torso phase")
+        if final_upright_dot < 0.45:
+            score -= (0.45 - final_upright_dot) * 20.0
+            reasons.append("motion does not return near upright")
+
+    if _is_stationary_prompt(prompt or clip.prompt):
+        drift = float(metrics["root_drift_ratio"])
+        if drift > options.max_root_drift_ratio:
+            score -= (drift - options.max_root_drift_ratio) * 18.0
+            reasons.append("root drifts too far for a stationary prompt")
+
+    if float(metrics["leg_reach_ratio_min"]) < options.min_leg_reach_ratio:
+        reasons.append("leg chain collapses too tightly")
+    if float(metrics["foot_head_distance_min_ratio"]) < options.min_foot_head_distance_ratio:
+        reasons.append("foot gets too close to head/face")
+    if float(metrics["knee_angle_min_degrees"]) < options.min_knee_angle_degrees:
+        reasons.append("knee fold angle is too extreme")
+    if float(metrics["leg_direction_acceleration_mean"]) > options.max_leg_direction_acceleration:
+        reasons.append("airborne leg direction changes too abruptly")
+
+    score = float(np.clip(score, 0.0, 100.0))
+    passed = score >= options.min_score and not any(
+        reason
+        in {
+            "missing posed_joints; cannot evaluate Kimodo skeleton quality",
+            "non-finite joint values",
+        }
+        for reason in reasons
+    )
+    return MotionQualityReport(
+        path=str(clip.source_path),
+        score=score,
+        passed=passed,
+        reasons=reasons,
+        metrics={key: _finite_or_default(value) if isinstance(value, float) else value for key, value in metrics.items()},
+    )
+
+
+def score_motion_file(
+    path: Path,
+    *,
+    prompt: str | None = None,
+    options: MotionQualityOptions | None = None,
+    gem_param_group: str = "body_params_global",
+) -> MotionQualityReport:
+    clip = load_motion_file(path, gem_param_group=gem_param_group)
+    return score_motion_clip(clip, prompt=prompt, options=options)
+
+
+def rank_motion_files(
+    paths: list[Path],
+    *,
+    prompt: str | None = None,
+    options: MotionQualityOptions | None = None,
+    gem_param_group: str = "body_params_global",
+) -> list[MotionQualityReport]:
+    reports = [
+        score_motion_file(
+            path,
+            prompt=prompt,
+            options=options,
+            gem_param_group=gem_param_group,
+        )
+        for path in paths
+    ]
+    return sorted(reports, key=lambda report: report.score, reverse=True)
+
+
+def write_motion_quality_report(path: Path, reports: list[MotionQualityReport]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "selected": reports[0].to_dict() if reports else None,
+                "candidates": [report.to_dict() for report in reports],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -47,7 +47,11 @@ class AvatarActionRequest:
     foot_orientation_lock: bool = True
     foot_contact_height: float = 0.12
     foot_lock_blend_frames: int = 4
+    airborne_leg_stabilization: bool = False
+    airborne_leg_stabilization_strength: float = 0.85
+    airborne_tuck_reach_ratio: float = 0.52
     calibrated_leg_ik: bool = True
+    body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
@@ -97,7 +101,11 @@ class AvatarActionPipeline:
             foot_orientation_lock=request.foot_orientation_lock,
             foot_contact_height=request.foot_contact_height,
             foot_lock_blend_frames=request.foot_lock_blend_frames,
+            airborne_leg_stabilization=request.airborne_leg_stabilization,
+            airborne_leg_stabilization_strength=request.airborne_leg_stabilization_strength,
+            airborne_tuck_reach_ratio=request.airborne_tuck_reach_ratio,
             calibrated_leg_ik=request.calibrated_leg_ik,
+            body_relative_leg_ik=request.body_relative_leg_ik,
             prefer_joint_position_ik=request.prefer_joint_position_ik,
             solidify_shell=request.solidify_shell,
             body_shell_thickness=request.body_shell_thickness,

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -44,6 +44,7 @@ class AvatarActionRequest:
     preserve_root_motion: bool = False
     stabilize_root_yaw: bool = False
     foot_contact_lock: bool = False
+    foot_orientation_lock: bool = True
     foot_contact_height: float = 0.12
     foot_lock_blend_frames: int = 4
     calibrated_leg_ik: bool = True
@@ -93,6 +94,7 @@ class AvatarActionPipeline:
             preserve_root_motion=request.preserve_root_motion,
             stabilize_root_yaw=request.stabilize_root_yaw,
             foot_contact_lock=request.foot_contact_lock,
+            foot_orientation_lock=request.foot_orientation_lock,
             foot_contact_height=request.foot_contact_height,
             foot_lock_blend_frames=request.foot_lock_blend_frames,
             calibrated_leg_ik=request.calibrated_leg_ik,

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -42,6 +42,10 @@ class AvatarActionRequest:
     foot_rotation_scale: float = 0.35
     include_root_orientation: bool = True
     preserve_root_motion: bool = False
+    stabilize_root_yaw: bool = False
+    foot_contact_lock: bool = False
+    foot_contact_height: float = 0.12
+    foot_lock_blend_frames: int = 4
     calibrated_leg_ik: bool = True
     prefer_joint_position_ik: bool = False
     solidify_shell: bool = True
@@ -87,6 +91,10 @@ class AvatarActionPipeline:
             foot_rotation_scale=request.foot_rotation_scale,
             include_root_orientation=request.include_root_orientation,
             preserve_root_motion=request.preserve_root_motion,
+            stabilize_root_yaw=request.stabilize_root_yaw,
+            foot_contact_lock=request.foot_contact_lock,
+            foot_contact_height=request.foot_contact_height,
+            foot_lock_blend_frames=request.foot_lock_blend_frames,
             calibrated_leg_ik=request.calibrated_leg_ik,
             prefer_joint_position_ik=request.prefer_joint_position_ik,
             solidify_shell=request.solidify_shell,

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from havln3.avatar_assets import select_avatar
-from havln3.motion import generate_kimodo_motion, load_motion_file
+from havln3.motion import generate_kimodo_motion_candidates, load_motion_file
+from havln3.motion_quality import MotionQualityOptions, rank_motion_files, write_motion_quality_report
 from havln3.retarget import RetargetOptions, retarget_motion_to_avatar
 
 
@@ -31,6 +32,9 @@ class AvatarActionRequest:
     identity: str | None = None
     generator: str = "existing"
     kimodo_model: str = "Kimodo-SMPLX-RP-v1"
+    kimodo_num_samples: int = 1
+    motion_quality_select: bool = True
+    motion_quality_min_score: float = 62.0
     duration: float = 5.0
     seed: int | None = None
     frames: int = 120
@@ -79,7 +83,7 @@ class AvatarActionPipeline:
         avatar = avatar_match.asset
         asset_name = request.asset_name or _slugify(f"{avatar.display_name}_{request.prompt}")
         asset_dir = request.output_root / "Data" / "HAPS2_0" / asset_name
-        motion_path, amass_path = self._resolve_motion(request, asset_name)
+        motion_path, amass_path, motion_selection = self._resolve_motion(request, asset_name)
         motion = load_motion_file(
             motion_path,
             amass_path=amass_path,
@@ -129,6 +133,7 @@ class AvatarActionPipeline:
                 }
                 for match in top_matches
             ],
+            "motion": motion_selection,
         }
         report = retarget_motion_to_avatar(
             avatar_glb=avatar.path,
@@ -153,20 +158,68 @@ class AvatarActionPipeline:
             skeleton_path=asset_dir / "skeleton.json",
         )
 
-    def _resolve_motion(self, request: AvatarActionRequest, asset_name: str) -> tuple[Path, Path | None]:
+    def _resolve_motion(
+        self,
+        request: AvatarActionRequest,
+        asset_name: str,
+    ) -> tuple[Path, Path | None, dict[str, object]]:
         if request.motion_npz:
-            return request.motion_npz, request.amass_npz
+            return request.motion_npz, request.amass_npz, {
+                "mode": "provided",
+                "selected": str(request.motion_npz),
+                "amass": str(request.amass_npz) if request.amass_npz else None,
+            }
         if request.gem_smpl_params:
-            return request.gem_smpl_params, None
+            return request.gem_smpl_params, None, {
+                "mode": "provided_gem",
+                "selected": str(request.gem_smpl_params),
+                "amass": None,
+            }
         if request.generator == "kimodo":
             output_stem = request.output_root / "motion_generation" / asset_name / asset_name
-            return generate_kimodo_motion(
+            generated = generate_kimodo_motion_candidates(
                 request.prompt,
                 output_stem,
                 model=request.kimodo_model,
                 duration=request.duration,
                 seed=request.seed,
+                num_samples=request.kimodo_num_samples,
             )
+            if not generated:
+                raise RuntimeError(f"Kimodo did not produce .npz motion files under {output_stem.parent}")
+            if len(generated) == 1 or not request.motion_quality_select:
+                selected, amass = generated[0]
+                return selected, amass, {
+                    "mode": "kimodo",
+                    "quality_select": False,
+                    "selected": str(selected),
+                    "amass": str(amass) if amass else None,
+                    "candidates": [str(path) for path, _ in generated],
+                }
+
+            amass_by_motion = {motion_path: amass_path for motion_path, amass_path in generated}
+            quality_options = MotionQualityOptions(min_score=request.motion_quality_min_score)
+            quality_reports = rank_motion_files(
+                [motion_path for motion_path, _ in generated],
+                prompt=request.prompt,
+                options=quality_options,
+                gem_param_group=request.gem_param_group,
+            )
+            quality_report_path = output_stem.parent / "motion_quality_report.json"
+            write_motion_quality_report(quality_report_path, quality_reports)
+            best = quality_reports[0]
+            best_path = Path(best.path)
+            return best_path, amass_by_motion.get(best_path), {
+                "mode": "kimodo",
+                "quality_select": True,
+                "selected": str(best_path),
+                "amass": str(amass_by_motion.get(best_path)) if amass_by_motion.get(best_path) else None,
+                "quality_report": str(quality_report_path),
+                "best_score": best.score,
+                "best_passed": best.passed,
+                "best_reasons": best.reasons,
+                "candidate_count": len(quality_reports),
+            }
         raise ValueError(
             "No motion source was provided. Pass --motion-npz/--gem-smpl-params, "
             "or use --generator kimodo in an environment where kimodo_gen is installed."

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from havln3.avatar_assets import select_avatar
+from havln3.motion import generate_kimodo_motion, load_motion_file
+from havln3.retarget import RetargetOptions, retarget_motion_to_avatar
+
+
+def _slugify(text: str, *, max_length: int = 72) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", text.lower()).strip("_")
+    slug = re.sub(r"_+", "_", slug)
+    return (slug[:max_length].strip("_") or "avatar_action")
+
+
+@dataclass(frozen=True)
+class AvatarActionRequest:
+    prompt: str
+    output_root: Path
+    avatar_root: Path = Path("vico_assets_probe/models")
+    avatar_glb: Path | None = None
+    avatar_catalog: Path | None = None
+    motion_npz: Path | None = None
+    amass_npz: Path | None = None
+    gem_smpl_params: Path | None = None
+    gem_param_group: str = "body_params_global"
+    asset_name: str | None = None
+    identity: str | None = None
+    generator: str = "existing"
+    kimodo_model: str = "Kimodo-SMPLX-RP-v1"
+    duration: float = 5.0
+    seed: int | None = None
+    frames: int = 120
+    fps: int = 24
+    target_height: float = 1.72
+    ground_y: float = -0.2
+    rotation_scale: float = 0.65
+    lower_leg_rotation_scale: float = 0.18
+    foot_rotation_scale: float = 0.35
+    include_root_orientation: bool = True
+    preserve_root_motion: bool = False
+    calibrated_leg_ik: bool = True
+    prefer_joint_position_ik: bool = False
+    solidify_shell: bool = True
+    body_shell_thickness: float = 0.018
+    hair_shell_thickness: float = 0.006
+
+
+@dataclass(frozen=True)
+class AvatarActionResult:
+    asset_name: str
+    asset_dir: Path
+    avatar_glb: Path
+    motion_path: Path
+    report_path: Path
+    skeleton_path: Path
+
+
+class AvatarActionPipeline:
+    def run(self, request: AvatarActionRequest) -> AvatarActionResult:
+        avatar_match, top_matches = select_avatar(
+            request.prompt,
+            request.avatar_root,
+            preferred_avatar=request.avatar_glb,
+            catalog_path=request.avatar_catalog,
+        )
+        avatar = avatar_match.asset
+        asset_name = request.asset_name or _slugify(f"{avatar.display_name}_{request.prompt}")
+        asset_dir = request.output_root / "Data" / "HAPS2_0" / asset_name
+        motion_path, amass_path = self._resolve_motion(request, asset_name)
+        motion = load_motion_file(
+            motion_path,
+            amass_path=amass_path,
+            gem_param_group=request.gem_param_group,
+        )
+        identity = request.identity or avatar.display_name
+        options = RetargetOptions(
+            frames=request.frames,
+            fps=request.fps,
+            target_height=request.target_height,
+            ground_y=request.ground_y,
+            rotation_scale=request.rotation_scale,
+            lower_leg_rotation_scale=request.lower_leg_rotation_scale,
+            foot_rotation_scale=request.foot_rotation_scale,
+            include_root_orientation=request.include_root_orientation,
+            preserve_root_motion=request.preserve_root_motion,
+            calibrated_leg_ik=request.calibrated_leg_ik,
+            prefer_joint_position_ik=request.prefer_joint_position_ik,
+            solidify_shell=request.solidify_shell,
+            body_shell_thickness=request.body_shell_thickness,
+            hair_shell_thickness=request.hair_shell_thickness,
+        )
+        selection = {
+            "selected": {
+                "path": str(avatar.path),
+                "display_name": avatar.display_name,
+                "provider": avatar.provider,
+                "score": avatar_match.score,
+                "reasons": list(avatar_match.reasons),
+                "tags": sorted(avatar.tags),
+            },
+            "top_candidates": [
+                {
+                    "path": str(match.asset.path),
+                    "display_name": match.asset.display_name,
+                    "score": match.score,
+                    "reasons": list(match.reasons),
+                }
+                for match in top_matches
+            ],
+        }
+        report = retarget_motion_to_avatar(
+            avatar_glb=avatar.path,
+            motion=motion,
+            output_dir=asset_dir,
+            asset_name=asset_name,
+            prompt=request.prompt,
+            identity=identity,
+            options=options,
+            selection=selection,
+        )
+        report_dir = request.output_root / "reports"
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_path = report_dir / f"{asset_name}_retarget_report.json"
+        report_path.write_text(json.dumps({**report, "selection": selection}, indent=2), encoding="utf-8")
+        return AvatarActionResult(
+            asset_name=asset_name,
+            asset_dir=asset_dir,
+            avatar_glb=avatar.path,
+            motion_path=motion_path,
+            report_path=report_path,
+            skeleton_path=asset_dir / "skeleton.json",
+        )
+
+    def _resolve_motion(self, request: AvatarActionRequest, asset_name: str) -> tuple[Path, Path | None]:
+        if request.motion_npz:
+            return request.motion_npz, request.amass_npz
+        if request.gem_smpl_params:
+            return request.gem_smpl_params, None
+        if request.generator == "kimodo":
+            output_stem = request.output_root / "motion_generation" / asset_name / asset_name
+            return generate_kimodo_motion(
+                request.prompt,
+                output_stem,
+                model=request.kimodo_model,
+                duration=request.duration,
+                seed=request.seed,
+            )
+        raise ValueError(
+            "No motion source was provided. Pass --motion-npz/--gem-smpl-params, "
+            "or use --generator kimodo in an environment where kimodo_gen is installed."
+        )

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -72,6 +72,10 @@ class RetargetOptions:
     preserve_root_motion: bool = False
     root_motion_scale: float = 1.0
     snap_to_ground: bool = True
+    stabilize_root_yaw: bool = False
+    foot_contact_lock: bool = False
+    foot_contact_height: float = 0.12
+    foot_lock_blend_frames: int = 4
     alpha_cutoff: float = 0.55
     material_roughness: float = 0.88
     detect_texture_alpha: bool = True
@@ -99,6 +103,12 @@ class LegCalibration:
     rest_pole_knee_local: np.ndarray
     rest_pole_foot_local: np.ndarray | None
     rest_toe_local: np.ndarray | None
+
+
+@dataclass
+class FrameGeometry:
+    vertices_by_primitive: list[np.ndarray]
+    joints: np.ndarray | None
 
 
 def _scaled_quat_from_matrix(matrix: np.ndarray, scale: float) -> np.ndarray:
@@ -473,6 +483,294 @@ def _root_offset(clip: MotionClip, frame_index: int, *, options: RetargetOptions
     return np.asarray(raw, dtype=np.float64)
 
 
+def _wrap_angle(angle: float) -> float:
+    return float((angle + np.pi) % (2.0 * np.pi) - np.pi)
+
+
+def _translate_frame(frame: FrameGeometry, delta: np.ndarray) -> None:
+    frame.vertices_by_primitive = [vertices + delta for vertices in frame.vertices_by_primitive]
+    if frame.joints is not None:
+        frame.joints = frame.joints + delta
+
+
+def _rotate_y(points: np.ndarray, angle: float, pivot: np.ndarray) -> np.ndarray:
+    rotation = Rotation.from_euler("y", angle).as_matrix()
+    return (points - pivot) @ rotation.T + pivot
+
+
+def _rotate_frame_y(frame: FrameGeometry, angle: float, pivot: np.ndarray) -> None:
+    frame.vertices_by_primitive = [_rotate_y(vertices, angle, pivot) for vertices in frame.vertices_by_primitive]
+    if frame.joints is not None:
+        frame.joints = _rotate_y(frame.joints, angle, pivot)
+
+
+def _joint_index(joint_by_name: dict[str, int], *names: str) -> int | None:
+    for name in names:
+        index = joint_by_name.get(name)
+        if index is not None:
+            return index
+    return None
+
+
+def _joint_point(
+    joints: np.ndarray,
+    joint_by_name: dict[str, int],
+    *names: str,
+) -> np.ndarray | None:
+    index = _joint_index(joint_by_name, *names)
+    if index is None:
+        return None
+    return joints[index]
+
+
+def _root_yaw_from_joints(joints: np.ndarray, joint_by_name: dict[str, int]) -> float | None:
+    left = _joint_point(joints, joint_by_name, "LeftUpLeg", "LeftLeg", "LeftFoot")
+    right = _joint_point(joints, joint_by_name, "RightUpLeg", "RightLeg", "RightFoot")
+    if left is None or right is None:
+        return None
+    side = right - left
+    side[1] = 0.0
+    side_unit = _safe_unit(side)
+    if side_unit is None:
+        return None
+    return float(np.arctan2(side_unit[2], side_unit[0]))
+
+
+def _frame_pivot(frame: FrameGeometry, joint_by_name: dict[str, int]) -> np.ndarray:
+    if frame.joints is not None:
+        hips = _joint_point(frame.joints, joint_by_name, "Hips")
+        if hips is not None:
+            return hips
+        return frame.joints.mean(axis=0)
+    return np.vstack(frame.vertices_by_primitive).mean(axis=0)
+
+
+def _apply_root_yaw_stabilization(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+) -> dict[str, Any]:
+    reference_yaw: float | None = None
+    yaw_deltas: list[float] = []
+    for frame in frames:
+        if frame.joints is None:
+            continue
+        yaw = _root_yaw_from_joints(frame.joints.copy(), joint_by_name)
+        if yaw is None:
+            continue
+        reference_yaw = yaw
+        break
+
+    if reference_yaw is None:
+        return {"enabled": True, "frames_adjusted": 0, "reason": "missing hip/leg joints"}
+
+    for frame in frames:
+        if frame.joints is None:
+            continue
+        yaw = _root_yaw_from_joints(frame.joints.copy(), joint_by_name)
+        if yaw is None:
+            yaw_deltas.append(0.0)
+            continue
+        delta = _wrap_angle(yaw - reference_yaw)
+        yaw_deltas.append(delta)
+        if abs(delta) > 1e-6:
+            _rotate_frame_y(frame, delta, _frame_pivot(frame, joint_by_name))
+
+    return {
+        "enabled": True,
+        "reference_yaw_degrees": float(np.degrees(reference_yaw)),
+        "frames_adjusted": int(sum(abs(delta) > 1e-6 for delta in yaw_deltas)),
+        "max_yaw_delta_degrees": float(np.degrees(max((abs(delta) for delta in yaw_deltas), default=0.0))),
+    }
+
+
+def _foot_points(
+    joints: np.ndarray,
+    joint_by_name: dict[str, int],
+    side: str,
+) -> tuple[np.ndarray | None, float | None]:
+    indices = [
+        joint_by_name[name]
+        for name in (f"{side}Foot", f"{side}ToeBase")
+        if name in joint_by_name
+    ]
+    if not indices:
+        return None, None
+    points = joints[indices]
+    return points.mean(axis=0), float(points[:, 1].min())
+
+
+def _contiguous_segments(mask: np.ndarray) -> list[tuple[int, int]]:
+    segments: list[tuple[int, int]] = []
+    start: int | None = None
+    for index, value in enumerate(mask):
+        if value and start is None:
+            start = index
+        elif not value and start is not None:
+            segments.append((start, index - 1))
+            start = None
+    if start is not None:
+        segments.append((start, len(mask) - 1))
+    return segments
+
+
+def _edge_blend_weight(index: int, start: int, end: int, frame_count: int, blend_frames: int) -> float:
+    if blend_frames <= 0:
+        return 1.0
+    weight = 1.0
+    if start > 0:
+        weight = min(weight, (index - start + 1) / (blend_frames + 1))
+    if end < frame_count - 1:
+        weight = min(weight, (end - index + 1) / (blend_frames + 1))
+    return float(np.clip(weight, 0.0, 1.0))
+
+
+def _source_foot_contact_mask(foot_contacts: np.ndarray | None, frame_count: int) -> np.ndarray | None:
+    if foot_contacts is None or len(foot_contacts) != frame_count:
+        return None
+    if foot_contacts.ndim != 2 or foot_contacts.shape[1] < 2:
+        return None
+    contacts = foot_contacts.astype(bool)
+    left = contacts[:, : min(2, contacts.shape[1])].any(axis=1)
+    if contacts.shape[1] >= 4:
+        right = contacts[:, 2:4].any(axis=1)
+    else:
+        right = contacts[:, -1]
+    return np.column_stack([left, right])
+
+
+def _select_lock_segments(support_mask: np.ndarray) -> list[tuple[int, int]]:
+    frame_count = len(support_mask)
+    segments = _contiguous_segments(support_mask)
+    selected: list[tuple[int, int]] = []
+    start_window_end = max(1, frame_count // 5)
+    landing_window_start = max(0, int(frame_count * 0.55))
+    for start, end in segments:
+        if start <= start_window_end or end >= landing_window_start:
+            selected.append((start, end))
+    if not any(end >= landing_window_start for _, end in selected):
+        lock_frames = max(3, min(8, frame_count // 5))
+        selected.append((frame_count - lock_frames, frame_count - 1))
+    return selected
+
+
+def _apply_foot_contact_lock(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    *,
+    ground_y: float,
+    contact_height: float,
+    blend_frames: int,
+    source_foot_contacts: np.ndarray | None = None,
+) -> dict[str, Any]:
+    frame_count = len(frames)
+    centers = np.full((frame_count, 2, 3), np.nan, dtype=np.float64)
+    lows = np.full((frame_count, 2), np.nan, dtype=np.float64)
+    for frame_index, frame in enumerate(frames):
+        if frame.joints is None:
+            continue
+        for side_index, side in enumerate(("Left", "Right")):
+            center, low = _foot_points(frame.joints, joint_by_name, side)
+            if center is not None and low is not None:
+                centers[frame_index, side_index] = center
+                lows[frame_index, side_index] = low
+
+    if np.isnan(lows).all():
+        return {"enabled": True, "locked_frames": 0, "reason": "missing foot joints"}
+
+    contact_mask = lows <= (ground_y + contact_height)
+    source_mask = _source_foot_contact_mask(source_foot_contacts, frame_count)
+    if source_mask is not None:
+        contact_mask = contact_mask | (source_mask & (lows <= ground_y + contact_height * 2.0))
+    contact_mask = np.nan_to_num(contact_mask, nan=False).astype(bool)
+    support_mask = contact_mask.any(axis=1)
+    segments = _select_lock_segments(support_mask)
+
+    locked_frames: set[int] = set()
+    applied_segments: list[dict[str, Any]] = []
+    for start, end in segments:
+        if start > end:
+            continue
+        segment_mask = contact_mask[start : end + 1]
+        side_indices = [index for index in range(2) if segment_mask[:, index].any()]
+        if not side_indices:
+            anchor_lows = lows[start]
+            if np.isnan(anchor_lows).all():
+                continue
+            side_indices = [int(np.nanargmin(anchor_lows))]
+
+        anchor_frame = start
+        segment_record = {
+            "start": int(start),
+            "end": int(end),
+            "anchor_frame": int(anchor_frame),
+            "sides": ["Left" if index == 0 else "Right" for index in side_indices],
+        }
+        applied_segments.append(segment_record)
+        for frame_index in range(start, end + 1):
+            deltas = []
+            for side_index in side_indices:
+                current = centers[frame_index, side_index]
+                anchor = centers[anchor_frame, side_index]
+                low = lows[frame_index, side_index]
+                if np.isnan(current).any() or np.isnan(anchor).any() or np.isnan(low):
+                    continue
+                delta = np.array(
+                    [
+                        anchor[0] - current[0],
+                        ground_y - low,
+                        anchor[2] - current[2],
+                    ],
+                    dtype=np.float64,
+                )
+                deltas.append(delta)
+            if not deltas:
+                continue
+            weight = _edge_blend_weight(frame_index, start, end, frame_count, blend_frames)
+            delta = np.mean(deltas, axis=0) * weight
+            _translate_frame(frames[frame_index], delta)
+            locked_frames.add(frame_index)
+
+    ground_lifts = 0
+    for frame in frames:
+        lowest = min(float(vertices[:, 1].min()) for vertices in frame.vertices_by_primitive)
+        if lowest < ground_y:
+            _translate_frame(frame, np.array([0.0, ground_y - lowest, 0.0], dtype=np.float64))
+            ground_lifts += 1
+
+    return {
+        "enabled": True,
+        "locked_frames": len(locked_frames),
+        "segments": applied_segments,
+        "ground_lift_frames": ground_lifts,
+        "contact_height": contact_height,
+        "blend_frames": blend_frames,
+    }
+
+
+def _postprocess_frames(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    clip: MotionClip,
+    options: RetargetOptions,
+) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "root_yaw_stabilization": {"enabled": False},
+        "foot_contact_lock": {"enabled": False},
+    }
+    if options.stabilize_root_yaw:
+        report["root_yaw_stabilization"] = _apply_root_yaw_stabilization(frames, joint_by_name)
+    if options.foot_contact_lock:
+        report["foot_contact_lock"] = _apply_foot_contact_lock(
+            frames,
+            joint_by_name,
+            ground_y=options.ground_y,
+            contact_height=options.foot_contact_height,
+            blend_frames=options.foot_lock_blend_frames,
+            source_foot_contacts=clip.foot_contacts,
+        )
+    return report
+
+
 def _boundary_edges(faces: np.ndarray) -> np.ndarray:
     edges = np.vstack([faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [2, 0]]])
     sorted_edges = np.sort(edges, axis=1)
@@ -597,7 +895,7 @@ def retarget_motion_to_avatar(
 
     material_changes: dict[str, Any] = {}
     bounds: list[dict[str, list[float]]] = []
-    skeleton_frames: list[list[list[float]]] = []
+    frame_geometries: list[FrameGeometry] = []
     joint_names = [joint_base_name(gltf.nodes[joint].name) for joint in skin.joints]
 
     for frame_index in range(options.frames):
@@ -623,11 +921,18 @@ def retarget_motion_to_avatar(
             root_offset=_root_offset(clip, frame_index, options=options),
             snap_to_ground=options.snap_to_ground,
         )
-        if transformed_joints is not None:
-            skeleton_frames.append(transformed_joints.tolist())
+        frame_geometries.append(FrameGeometry(vertices_by_primitive=transformed, joints=transformed_joints))
 
+    postprocess = _postprocess_frames(frame_geometries, joint_by_name, clip, options)
+    skeleton_frames = [
+        frame.joints.tolist()
+        for frame in frame_geometries
+        if frame.joints is not None
+    ]
+
+    for frame_index, frame in enumerate(frame_geometries):
         glb_path = output_dir / f"frame{frame_index:03d}.glb"
-        _export_frame(glb_path, transformed, source_geometries, options=options)
+        _export_frame(glb_path, frame.vertices_by_primitive, source_geometries, options=options)
         material_changes[glb_path.name] = fix_habitat_materials(
             glb_path,
             alpha_cutoff=options.alpha_cutoff,
@@ -636,7 +941,7 @@ def retarget_motion_to_avatar(
         )
         write_object_config(output_dir / f"frame{frame_index:03d}.object_config.json", glb_path)
 
-        combined = np.vstack(transformed)
+        combined = np.vstack(frame.vertices_by_primitive)
         bounds.append({"min": combined.min(axis=0).tolist(), "max": combined.max(axis=0).tolist()})
 
     skeleton = {
@@ -649,6 +954,7 @@ def retarget_motion_to_avatar(
             "strategy": "calibrated two-bone IK with target-rig knee pole constraints",
             "legs": [calibration.side for calibration in leg_calibrations],
         },
+        "postprocess": postprocess,
     }
     (output_dir / "skeleton.json").write_text(json.dumps(skeleton, indent=2), encoding="utf-8")
 
@@ -663,7 +969,8 @@ def retarget_motion_to_avatar(
         "appearance_strategy": "preserve original ViCo/Mixamo skinned GLB mesh, UVs, skin weights, and textures",
         "retarget_strategy": (
             "map SMPL-22/GEM/Kimodo local rotations to compatible ViCo/Mixamo skin joints; "
-            "when posed joints are available, solve calibrated two-bone leg IK using the target rig knee pole"
+            "when posed joints are available, solve calibrated two-bone leg IK using the target rig knee pole; "
+            "optionally stabilize root yaw and lock support feet during contact/landing"
         ),
         "selection": selection or {},
         "material_strategy": {
@@ -674,6 +981,7 @@ def retarget_motion_to_avatar(
             "body_shell_thickness_m": options.body_shell_thickness,
             "hair_shell_thickness_m": options.hair_shell_thickness,
         },
+        "postprocess": postprocess,
     }
     (output_dir / "persona.json").write_text(json.dumps(persona, indent=2), encoding="utf-8")
     (output_dir / "habitat_material_fix_report.json").write_text(
@@ -695,5 +1003,6 @@ def retarget_motion_to_avatar(
         "max_top_y": max(item["max"][1] for item in bounds),
         "max_height": max(item["max"][1] - item["min"][1] for item in bounds),
         "leg_ik": skeleton["leg_ik"],
+        "postprocess": postprocess,
     }
     return report

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -58,6 +58,8 @@ SMPL_LEG_JOINTS = {
     "Right": {"hip": 2, "knee": 5, "ankle": 8, "toe": 11},
 }
 
+GLTF_UP = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+
 
 @dataclass(frozen=True)
 class RetargetOptions:
@@ -74,6 +76,7 @@ class RetargetOptions:
     snap_to_ground: bool = True
     stabilize_root_yaw: bool = False
     foot_contact_lock: bool = False
+    foot_orientation_lock: bool = True
     foot_contact_height: float = 0.12
     foot_lock_blend_frames: int = 4
     alpha_cutoff: float = 0.55
@@ -103,12 +106,22 @@ class LegCalibration:
     rest_pole_knee_local: np.ndarray
     rest_pole_foot_local: np.ndarray | None
     rest_toe_local: np.ndarray | None
+    rest_foot_up_local: np.ndarray | None
+    rest_contact_toe_global: np.ndarray | None
 
 
 @dataclass
 class FrameGeometry:
     vertices_by_primitive: list[np.ndarray]
     joints: np.ndarray | None
+
+
+@dataclass(frozen=True)
+class FootContactAnalysis:
+    centers: np.ndarray
+    lows: np.ndarray
+    contact_mask: np.ndarray
+    segments: list[tuple[int, int]]
 
 
 def _scaled_quat_from_matrix(matrix: np.ndarray, scale: float) -> np.ndarray:
@@ -263,6 +276,8 @@ def _leg_calibrations(
 
         rest_upper = knee_pos - hip_pos
         rest_lower = ankle_pos - knee_pos
+        rest_toe = rest_positions[toe] - ankle_pos if toe is not None else None
+        rest_contact_toe = _projected_unit(rest_toe, GLTF_UP) if rest_toe is not None else None
         calibrations.append(
             LegCalibration(
                 side=side,
@@ -279,11 +294,9 @@ def _leg_calibrations(
                 rest_pole_hip_local=rest_rotations[hip].inv().apply(pole),
                 rest_pole_knee_local=rest_rotations[knee].inv().apply(pole),
                 rest_pole_foot_local=rest_rotations[ankle].inv().apply(pole) if toe is not None else None,
-                rest_toe_local=(
-                    rest_rotations[ankle].inv().apply(rest_positions[toe] - ankle_pos)
-                    if toe is not None
-                    else None
-                ),
+                rest_toe_local=rest_rotations[ankle].inv().apply(rest_toe) if rest_toe is not None else None,
+                rest_foot_up_local=rest_rotations[ankle].inv().apply(GLTF_UP) if toe is not None else None,
+                rest_contact_toe_global=rest_contact_toe,
             )
         )
     return calibrations
@@ -624,6 +637,16 @@ def _edge_blend_weight(index: int, start: int, end: int, frame_count: int, blend
     return float(np.clip(weight, 0.0, 1.0))
 
 
+def _blend_rotation(source: Rotation, target: Rotation, weight: float) -> Rotation:
+    weight = float(np.clip(weight, 0.0, 1.0))
+    if weight <= 0.0:
+        return source
+    if weight >= 1.0:
+        return target
+    delta = target * source.inv()
+    return Rotation.from_rotvec(delta.as_rotvec() * weight) * source
+
+
 def _source_foot_contact_mask(foot_contacts: np.ndarray | None, frame_count: int) -> np.ndarray | None:
     if foot_contacts is None or len(foot_contacts) != frame_count:
         return None
@@ -647,21 +670,26 @@ def _select_lock_segments(support_mask: np.ndarray) -> list[tuple[int, int]]:
     for start, end in segments:
         if start <= start_window_end or end >= landing_window_start:
             selected.append((start, end))
-    if not any(end >= landing_window_start for _, end in selected):
+    landing_indices = [index for index, (start, end) in enumerate(selected) if end >= landing_window_start]
+    if landing_indices:
+        index = landing_indices[-1]
+        start, end = selected[index]
+        if start >= landing_window_start and end < frame_count - 1:
+            selected[index] = (start, frame_count - 1)
+    else:
         lock_frames = max(3, min(8, frame_count // 5))
         selected.append((frame_count - lock_frames, frame_count - 1))
     return selected
 
 
-def _apply_foot_contact_lock(
+def _foot_contact_analysis(
     frames: list[FrameGeometry],
     joint_by_name: dict[str, int],
     *,
     ground_y: float,
     contact_height: float,
-    blend_frames: int,
     source_foot_contacts: np.ndarray | None = None,
-) -> dict[str, Any]:
+) -> FootContactAnalysis | None:
     frame_count = len(frames)
     centers = np.full((frame_count, 2, 3), np.nan, dtype=np.float64)
     lows = np.full((frame_count, 2), np.nan, dtype=np.float64)
@@ -675,7 +703,7 @@ def _apply_foot_contact_lock(
                 lows[frame_index, side_index] = low
 
     if np.isnan(lows).all():
-        return {"enabled": True, "locked_frames": 0, "reason": "missing foot joints"}
+        return None
 
     contact_mask = lows <= (ground_y + contact_height)
     source_mask = _source_foot_contact_mask(source_foot_contacts, frame_count)
@@ -683,7 +711,38 @@ def _apply_foot_contact_lock(
         contact_mask = contact_mask | (source_mask & (lows <= ground_y + contact_height * 2.0))
     contact_mask = np.nan_to_num(contact_mask, nan=False).astype(bool)
     support_mask = contact_mask.any(axis=1)
-    segments = _select_lock_segments(support_mask)
+    return FootContactAnalysis(
+        centers=centers,
+        lows=lows,
+        contact_mask=contact_mask,
+        segments=_select_lock_segments(support_mask),
+    )
+
+
+def _apply_foot_contact_lock(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    *,
+    ground_y: float,
+    contact_height: float,
+    blend_frames: int,
+    source_foot_contacts: np.ndarray | None = None,
+) -> dict[str, Any]:
+    frame_count = len(frames)
+    analysis = _foot_contact_analysis(
+        frames,
+        joint_by_name,
+        ground_y=ground_y,
+        contact_height=contact_height,
+        source_foot_contacts=source_foot_contacts,
+    )
+    if analysis is None:
+        return {"enabled": True, "locked_frames": 0, "reason": "missing foot joints"}
+
+    centers = analysis.centers
+    lows = analysis.lows
+    contact_mask = analysis.contact_mask
+    segments = analysis.segments
 
     locked_frames: set[int] = set()
     applied_segments: list[dict[str, Any]] = []
@@ -747,6 +806,139 @@ def _apply_foot_contact_lock(
     }
 
 
+def _apply_contact_foot_orientation_lock(
+    *,
+    local_quats_by_frame: list[np.ndarray],
+    rough_frames: list[FrameGeometry],
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    calibrations: list[LegCalibration],
+    clip: MotionClip,
+    options: RetargetOptions,
+) -> dict[str, Any]:
+    if not calibrations:
+        return {"enabled": True, "locked_frames": 0, "reason": "missing leg calibration"}
+
+    analysis = _foot_contact_analysis(
+        rough_frames,
+        joint_by_name,
+        ground_y=options.ground_y,
+        contact_height=options.foot_contact_height,
+        source_foot_contacts=clip.foot_contacts,
+    )
+    if analysis is None:
+        return {"enabled": True, "locked_frames": 0, "reason": "missing foot joints"}
+
+    skin = gltf.skins[0]
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
+    }
+    calibration_by_side = {calibration.side: calibration for calibration in calibrations}
+    reference_globals = node_global_matrices(gltf, local_quats_by_frame[0])
+    reference_toe_direction: dict[str, np.ndarray] = {}
+    for calibration in calibrations:
+        if calibration.toe is None:
+            continue
+        ankle_pos = reference_globals[skin.joints[calibration.ankle]][:3, 3]
+        toe_pos = reference_globals[skin.joints[calibration.toe]][:3, 3]
+        toe_direction = _projected_unit(toe_pos - ankle_pos, GLTF_UP)
+        if toe_direction is not None:
+            reference_toe_direction[calibration.side] = toe_direction
+
+    reference_yaw: float | None = None
+    if options.stabilize_root_yaw:
+        for frame in rough_frames:
+            if frame.joints is None:
+                continue
+            yaw = _root_yaw_from_joints(frame.joints.copy(), joint_by_name)
+            if yaw is not None:
+                reference_yaw = yaw
+                break
+
+    frame_count = len(local_quats_by_frame)
+    locked_frames: set[int] = set()
+    applied_segments: list[dict[str, Any]] = []
+
+    for start, end in analysis.segments:
+        if start > end:
+            continue
+        segment_mask = analysis.contact_mask[start : end + 1]
+        side_indices = [index for index in range(2) if segment_mask[:, index].any()]
+        if not side_indices:
+            continue
+
+        applied_segments.append(
+            {
+                "start": int(start),
+                "end": int(end),
+                "sides": ["Left" if index == 0 else "Right" for index in side_indices],
+            }
+        )
+        for frame_index in range(start, end + 1):
+            weight = _edge_blend_weight(frame_index, start, end, frame_count, options.foot_lock_blend_frames)
+            if weight <= 0.0:
+                continue
+            globals_ = node_global_matrices(gltf, local_quats_by_frame[frame_index])
+            for side_index in side_indices:
+                if not analysis.contact_mask[frame_index, side_index]:
+                    continue
+                side = "Left" if side_index == 0 else "Right"
+                calibration = calibration_by_side.get(side)
+                if (
+                    calibration is None
+                    or calibration.rest_toe_local is None
+                    or calibration.rest_foot_up_local is None
+                ):
+                    continue
+
+                parent_rotation = _rotation_from_matrix(globals_[skin.joints[calibration.knee]])
+                desired_toe_direction = reference_toe_direction.get(
+                    side,
+                    calibration.rest_contact_toe_global,
+                )
+                if desired_toe_direction is None:
+                    continue
+                if reference_yaw is not None and rough_frames[frame_index].joints is not None:
+                    yaw = _root_yaw_from_joints(rough_frames[frame_index].joints.copy(), joint_by_name)
+                    if yaw is not None:
+                        yaw_delta = _wrap_angle(yaw - reference_yaw)
+                        desired_toe_direction = Rotation.from_rotvec(GLTF_UP * yaw_delta).apply(
+                            desired_toe_direction
+                        )
+                desired_foot_rotation = _basis_rotation(
+                    calibration.rest_toe_local,
+                    calibration.rest_foot_up_local,
+                    desired_toe_direction,
+                    GLTF_UP,
+                )
+                target_delta = local_rest_rot[calibration.ankle].inv() * parent_rotation.inv() * desired_foot_rotation
+                current_delta = Rotation.from_quat(local_quats_by_frame[frame_index][calibration.ankle])
+                local_quats_by_frame[frame_index][calibration.ankle] = _blend_rotation(
+                    current_delta,
+                    target_delta,
+                    weight,
+                ).as_quat()
+                if calibration.toe is not None:
+                    current_toe_delta = Rotation.from_quat(local_quats_by_frame[frame_index][calibration.toe])
+                    local_quats_by_frame[frame_index][calibration.toe] = _blend_rotation(
+                        current_toe_delta,
+                        Rotation.identity(),
+                        weight,
+                    ).as_quat()
+                locked_frames.add(frame_index)
+
+    return {
+        "enabled": True,
+        "locked_frames": len(locked_frames),
+        "segments": applied_segments,
+        "strategy": (
+            "align contact foot toe vector to the initial stance direction, "
+            "align foot up to ground normal, and neutralize toe-base curl"
+        ),
+        "blend_frames": options.foot_lock_blend_frames,
+    }
+
+
 def _postprocess_frames(
     frames: list[FrameGeometry],
     joint_by_name: dict[str, int],
@@ -756,6 +948,7 @@ def _postprocess_frames(
     report: dict[str, Any] = {
         "root_yaw_stabilization": {"enabled": False},
         "foot_contact_lock": {"enabled": False},
+        "foot_orientation_lock": {"enabled": False},
     }
     if options.stabilize_root_yaw:
         report["root_yaw_stabilization"] = _apply_root_yaw_stabilization(frames, joint_by_name)
@@ -862,6 +1055,30 @@ def _export_frame(
     scene.export(glb_path, include_normals=True)
 
 
+def _build_frame_geometries(
+    *,
+    gltf: GLTF2,
+    skin: Any,
+    local_quats_by_frame: list[np.ndarray],
+    normalizer: VertexNormalizer,
+    clip: MotionClip,
+    options: RetargetOptions,
+) -> list[FrameGeometry]:
+    frames: list[FrameGeometry] = []
+    for frame_index, local_quats in enumerate(local_quats_by_frame):
+        deformed = deform_skinned_primitives(gltf, local_quats)
+        globals_ = node_global_matrices(gltf, local_quats)
+        joint_points = np.stack([globals_[joint][:3, 3] for joint in skin.joints])
+        transformed, transformed_joints = normalizer.transform(
+            deformed,
+            joint_points,
+            root_offset=_root_offset(clip, frame_index, options=options),
+            snap_to_ground=options.snap_to_ground,
+        )
+        frames.append(FrameGeometry(vertices_by_primitive=transformed, joints=transformed_joints))
+    return frames
+
+
 def retarget_motion_to_avatar(
     *,
     avatar_glb: Path,
@@ -895,7 +1112,7 @@ def retarget_motion_to_avatar(
 
     material_changes: dict[str, Any] = {}
     bounds: list[dict[str, list[float]]] = []
-    frame_geometries: list[FrameGeometry] = []
+    local_quats_by_frame: list[np.ndarray] = []
     joint_names = [joint_base_name(gltf.nodes[joint].name) for joint in skin.joints]
 
     for frame_index in range(options.frames):
@@ -912,18 +1129,38 @@ def retarget_motion_to_avatar(
                     gltf=gltf,
                     calibrations=leg_calibrations,
                 )
-        deformed = deform_skinned_primitives(gltf, local_quats)
-        globals_ = node_global_matrices(gltf, local_quats)
-        joint_points = np.stack([globals_[joint][:3, 3] for joint in skin.joints])
-        transformed, transformed_joints = normalizer.transform(
-            deformed,
-            joint_points,
-            root_offset=_root_offset(clip, frame_index, options=options),
-            snap_to_ground=options.snap_to_ground,
-        )
-        frame_geometries.append(FrameGeometry(vertices_by_primitive=transformed, joints=transformed_joints))
+        local_quats_by_frame.append(local_quats)
 
+    pre_postprocess: dict[str, Any] = {"foot_orientation_lock": {"enabled": False}}
+    if options.foot_contact_lock and options.foot_orientation_lock:
+        rough_frames = _build_frame_geometries(
+            gltf=gltf,
+            skin=skin,
+            local_quats_by_frame=local_quats_by_frame,
+            normalizer=normalizer,
+            clip=clip,
+            options=options,
+        )
+        pre_postprocess["foot_orientation_lock"] = _apply_contact_foot_orientation_lock(
+            local_quats_by_frame=local_quats_by_frame,
+            rough_frames=rough_frames,
+            gltf=gltf,
+            joint_by_name=joint_by_name,
+            calibrations=leg_calibrations,
+            clip=clip,
+            options=options,
+        )
+
+    frame_geometries = _build_frame_geometries(
+        gltf=gltf,
+        skin=skin,
+        local_quats_by_frame=local_quats_by_frame,
+        normalizer=normalizer,
+        clip=clip,
+        options=options,
+    )
     postprocess = _postprocess_frames(frame_geometries, joint_by_name, clip, options)
+    postprocess = {**postprocess, **pre_postprocess}
     skeleton_frames = [
         frame.joints.tolist()
         for frame in frame_geometries

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -549,6 +549,28 @@ def _root_yaw_from_joints(joints: np.ndarray, joint_by_name: dict[str, int]) -> 
     return float(np.arctan2(side_unit[2], side_unit[0]))
 
 
+def _body_forward_from_globals(
+    globals_: list[np.ndarray],
+    gltf: GLTF2,
+    skin: Any,
+    joint_by_name: dict[str, int],
+) -> np.ndarray | None:
+    for left_name, right_name in (("LeftShoulder", "RightShoulder"), ("LeftUpLeg", "RightUpLeg")):
+        left_index = joint_by_name.get(left_name)
+        right_index = joint_by_name.get(right_name)
+        if left_index is None or right_index is None:
+            continue
+        left = globals_[skin.joints[left_index]][:3, 3]
+        right = globals_[skin.joints[right_index]][:3, 3]
+        side = _projected_unit(right - left, GLTF_UP)
+        if side is None:
+            continue
+        forward = _safe_unit(np.cross(GLTF_UP, side))
+        if forward is not None:
+            return forward
+    return None
+
+
 def _frame_pivot(frame: FrameGeometry, joint_by_name: dict[str, int]) -> np.ndarray:
     if frame.joints is not None:
         hips = _joint_point(frame.joints, joint_by_name, "Hips")
@@ -835,15 +857,7 @@ def _apply_contact_foot_orientation_lock(
     }
     calibration_by_side = {calibration.side: calibration for calibration in calibrations}
     reference_globals = node_global_matrices(gltf, local_quats_by_frame[0])
-    reference_toe_direction: dict[str, np.ndarray] = {}
-    for calibration in calibrations:
-        if calibration.toe is None:
-            continue
-        ankle_pos = reference_globals[skin.joints[calibration.ankle]][:3, 3]
-        toe_pos = reference_globals[skin.joints[calibration.toe]][:3, 3]
-        toe_direction = _projected_unit(toe_pos - ankle_pos, GLTF_UP)
-        if toe_direction is not None:
-            reference_toe_direction[calibration.side] = toe_direction
+    reference_forward = _body_forward_from_globals(reference_globals, gltf, skin, joint_by_name)
 
     reference_yaw: float | None = None
     if options.stabilize_root_yaw:
@@ -892,10 +906,7 @@ def _apply_contact_foot_orientation_lock(
                     continue
 
                 parent_rotation = _rotation_from_matrix(globals_[skin.joints[calibration.knee]])
-                desired_toe_direction = reference_toe_direction.get(
-                    side,
-                    calibration.rest_contact_toe_global,
-                )
+                desired_toe_direction = reference_forward if reference_forward is not None else calibration.rest_contact_toe_global
                 if desired_toe_direction is None:
                     continue
                 if reference_yaw is not None and rough_frames[frame_index].joints is not None:
@@ -932,7 +943,7 @@ def _apply_contact_foot_orientation_lock(
         "locked_frames": len(locked_frames),
         "segments": applied_segments,
         "strategy": (
-            "align contact foot toe vector to the initial stance direction, "
+            "align contact foot toe vector to the target rig body-facing direction, "
             "align foot up to ground normal, and neutralize toe-base curl"
         ),
         "blend_frames": options.foot_lock_blend_frames,

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -59,6 +59,14 @@ SMPL_LEG_JOINTS = {
 }
 
 GLTF_UP = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+SOURCE_TO_AVATAR_AXES = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0],
+    ],
+    dtype=np.float64,
+)
 
 
 @dataclass(frozen=True)
@@ -79,10 +87,14 @@ class RetargetOptions:
     foot_orientation_lock: bool = True
     foot_contact_height: float = 0.12
     foot_lock_blend_frames: int = 4
+    airborne_leg_stabilization: bool = False
+    airborne_leg_stabilization_strength: float = 0.85
+    airborne_tuck_reach_ratio: float = 0.52
     alpha_cutoff: float = 0.55
     material_roughness: float = 0.88
     detect_texture_alpha: bool = True
     calibrated_leg_ik: bool = True
+    body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
@@ -122,6 +134,13 @@ class FootContactAnalysis:
     lows: np.ndarray
     contact_mask: np.ndarray
     segments: list[tuple[int, int]]
+
+
+@dataclass(frozen=True)
+class AirborneLegGuide:
+    direction_local: np.ndarray
+    reach_ratio: float
+    skip_foot_ik: bool = True
 
 
 def _scaled_quat_from_matrix(matrix: np.ndarray, scale: float) -> np.ndarray:
@@ -172,6 +191,10 @@ def _source_to_avatar_axes(points: np.ndarray) -> np.ndarray:
     return points[:, [0, 2, 1]]
 
 
+def _source_rotation_to_avatar_axes(matrix: np.ndarray) -> Rotation:
+    return Rotation.from_matrix(SOURCE_TO_AVATAR_AXES @ matrix @ SOURCE_TO_AVATAR_AXES.T)
+
+
 def _safe_unit(vector: np.ndarray) -> np.ndarray | None:
     norm = float(np.linalg.norm(vector))
     if norm < 1e-8:
@@ -190,6 +213,59 @@ def _node_parent_indices(gltf: GLTF2) -> dict[int, int]:
 def _projected_unit(vector: np.ndarray, normal: np.ndarray) -> np.ndarray | None:
     projected = vector - normal * float(np.dot(vector, normal))
     return _safe_unit(projected)
+
+
+def _orthonormal_body_basis(side: np.ndarray, up_hint: np.ndarray) -> np.ndarray | None:
+    side_unit = _safe_unit(side)
+    if side_unit is None:
+        return None
+    up_unit = _projected_unit(up_hint, side_unit)
+    if up_unit is None:
+        up_unit = _fallback_pole(side_unit)
+    forward_unit = _safe_unit(np.cross(side_unit, up_unit))
+    if forward_unit is None:
+        return None
+    up_unit = _safe_unit(np.cross(forward_unit, side_unit))
+    if up_unit is None:
+        return None
+    return np.column_stack([side_unit, up_unit, forward_unit])
+
+
+def _source_body_basis(source: np.ndarray) -> np.ndarray | None:
+    if len(source) <= 3:
+        return None
+    hips = source[0]
+    side = source[SMPL_LEG_JOINTS["Right"]["hip"]] - source[SMPL_LEG_JOINTS["Left"]["hip"]]
+    for spine_index in (9, 6, 3, 15):
+        if spine_index < len(source):
+            basis = _orthonormal_body_basis(side, source[spine_index] - hips)
+            if basis is not None:
+                return basis
+    return None
+
+
+def _target_body_basis_from_globals(
+    globals_: list[np.ndarray],
+    skin: Any,
+    joint_by_name: dict[str, int],
+) -> np.ndarray | None:
+    hips_index = joint_by_name.get("Hips")
+    left_index = joint_by_name.get("LeftUpLeg")
+    right_index = joint_by_name.get("RightUpLeg")
+    if hips_index is None or left_index is None or right_index is None:
+        return None
+    hips = globals_[skin.joints[hips_index]][:3, 3]
+    left = globals_[skin.joints[left_index]][:3, 3]
+    right = globals_[skin.joints[right_index]][:3, 3]
+    side = right - left
+    for spine_name in ("Spine2", "Spine1", "Spine", "Neck", "Head"):
+        spine_index = joint_by_name.get(spine_name)
+        if spine_index is None:
+            continue
+        basis = _orthonormal_body_basis(side, globals_[skin.joints[spine_index]][:3, 3] - hips)
+        if basis is not None:
+            return basis
+    return None
 
 
 def _fallback_pole(direction: np.ndarray) -> np.ndarray:
@@ -322,19 +398,59 @@ def _two_bone_knee_position(
     return knee, ankle
 
 
+def _source_body_relative_direction(
+    direction: np.ndarray,
+    *,
+    source_body_basis: np.ndarray | None = None,
+    target_body_basis: np.ndarray | None = None,
+    source_global_rotations: dict[int, Rotation] | None = None,
+    source_parent_index: int | None = None,
+    target_parent_rotation: Rotation = Rotation.identity(),
+) -> np.ndarray | None:
+    direction_unit = _safe_unit(direction)
+    if direction_unit is None:
+        return None
+    if source_body_basis is not None and target_body_basis is not None:
+        local_direction = source_body_basis.T @ direction_unit
+        mapped = target_body_basis @ local_direction
+        mapped_unit = _safe_unit(mapped)
+        return mapped_unit if mapped_unit is not None else direction_unit
+    if source_global_rotations is None or source_parent_index is None:
+        return direction_unit
+    source_parent_rotation = source_global_rotations.get(source_parent_index)
+    if source_parent_rotation is None:
+        return direction_unit
+    local_direction = source_parent_rotation.inv().apply(direction_unit)
+    mapped = target_parent_rotation.apply(local_direction)
+    mapped_unit = _safe_unit(mapped)
+    return mapped_unit if mapped_unit is not None else direction_unit
+
+
 def _apply_calibrated_leg_ik(
     *,
     local: np.ndarray,
     source_joints: np.ndarray,
+    source_global_rot_mats: np.ndarray | None,
     gltf: GLTF2,
+    joint_by_name: dict[str, int],
     calibrations: list[LegCalibration],
+    body_relative: bool,
+    leg_guide: dict[str, AirborneLegGuide] | None = None,
 ) -> np.ndarray:
     if not calibrations:
         return local
 
     skin = gltf.skins[0]
     source = _source_to_avatar_axes(source_joints.astype(np.float64))
+    source_basis = _source_body_basis(source) if body_relative else None
+    source_global_rotations: dict[int, Rotation] | None = None
+    if body_relative and source_global_rot_mats is not None:
+        source_global_rotations = {
+            index: _source_rotation_to_avatar_axes(source_global_rot_mats[index].astype(np.float64))
+            for index in range(min(len(source_global_rot_mats), len(SMPL22_TO_MIXAMO)))
+        }
     current_globals = node_global_matrices(gltf, local)
+    target_basis = _target_body_basis_from_globals(current_globals, skin, joint_by_name) if body_relative else None
     local_rest_rot = {
         skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
     }
@@ -344,22 +460,37 @@ def _apply_calibrated_leg_ik(
         source_hip = source[source_map["hip"]]
         source_knee = source[source_map["knee"]]
         source_ankle = source[source_map["ankle"]]
-        source_direction = _safe_unit(source_ankle - source_hip)
-        if source_direction is None:
-            continue
 
         source_upper_len = float(np.linalg.norm(source_knee - source_hip))
         source_lower_len = float(np.linalg.norm(source_ankle - source_knee))
         source_chain_len = source_upper_len + source_lower_len
         if source_chain_len < 1e-8:
             continue
-        reach_ratio = float(np.linalg.norm(source_ankle - source_hip) / source_chain_len)
+        guide = leg_guide.get(calibration.side) if leg_guide is not None else None
+        reach_ratio = (
+            guide.reach_ratio
+            if guide is not None
+            else float(np.linalg.norm(source_ankle - source_hip) / source_chain_len)
+        )
 
         parent_rot = (
             _rotation_from_matrix(current_globals[calibration.parent_node])
             if calibration.parent_node is not None
             else Rotation.identity()
         )
+        if guide is not None and target_basis is not None:
+            source_direction = _safe_unit(target_basis @ guide.direction_local)
+        else:
+            source_direction = _source_body_relative_direction(
+                source_ankle - source_hip,
+                source_body_basis=source_basis,
+                target_body_basis=target_basis,
+                source_global_rotations=source_global_rotations,
+                source_parent_index=SMPL22_PARENTS[source_map["hip"]],
+                target_parent_rotation=parent_rot,
+            )
+        if source_direction is None:
+            continue
         pole = parent_rot.apply(calibration.rest_pole_parent_local)
         pole = _projected_unit(pole, source_direction)
         if pole is None:
@@ -400,12 +531,20 @@ def _apply_calibrated_leg_ik(
         local[calibration.knee] = knee_delta.as_quat()
 
         if (
-            calibration.toe is not None
+            (guide is None or not guide.skip_foot_ik)
+            and calibration.toe is not None
             and calibration.rest_toe_local is not None
             and calibration.rest_pole_foot_local is not None
         ):
             source_toe = source[source_map["toe"]]
-            source_toe_direction = _safe_unit(source_toe - source_ankle)
+            source_toe_direction = _source_body_relative_direction(
+                source_toe - source_ankle,
+                source_body_basis=source_basis,
+                target_body_basis=target_basis,
+                source_global_rotations=source_global_rotations,
+                source_parent_index=source_map["knee"],
+                target_parent_rotation=hip_global_rot * local_rest_rot[calibration.knee] * knee_delta,
+            )
             if source_toe_direction is not None:
                 knee_global_rot = hip_global_rot * local_rest_rot[calibration.knee] * knee_delta
                 desired_foot_rot = _basis_rotation(
@@ -739,6 +878,149 @@ def _foot_contact_analysis(
         contact_mask=contact_mask,
         segments=_select_lock_segments(support_mask),
     )
+
+
+def _smooth_unit_vectors(vectors: np.ndarray, valid: np.ndarray, *, radius: int = 2) -> np.ndarray:
+    smoothed = vectors.copy()
+    for index in range(len(vectors)):
+        if not valid[index]:
+            continue
+        start = max(0, index - radius)
+        end = min(len(vectors), index + radius + 1)
+        window = vectors[start:end][valid[start:end]]
+        if len(window) == 0:
+            continue
+        average = _safe_unit(window.mean(axis=0))
+        if average is not None:
+            smoothed[index] = average
+    return smoothed
+
+
+def _canonical_airborne_leg_direction(side: str, tuck: float) -> np.ndarray:
+    side_offset = -0.08 if side == "Left" else 0.08
+    extended = np.array([side_offset, -0.98, 0.08], dtype=np.float64)
+    tucked = np.array([side_offset, -0.20, 0.98], dtype=np.float64)
+    blended = extended * (1.0 - tuck) + tucked * tuck
+    direction = _safe_unit(blended)
+    return direction if direction is not None else tucked
+
+
+def _airborne_leg_guides(
+    *,
+    clip: MotionClip,
+    rough_frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    options: RetargetOptions,
+) -> tuple[list[dict[str, AirborneLegGuide] | None], dict[str, Any]]:
+    frame_count = len(rough_frames)
+    guides: list[dict[str, AirborneLegGuide] | None] = [None for _ in range(frame_count)]
+    if clip.posed_joints is None:
+        return guides, {"enabled": True, "guided_frames": 0, "reason": "missing posed joints"}
+
+    analysis = _foot_contact_analysis(
+        rough_frames,
+        joint_by_name,
+        ground_y=options.ground_y,
+        contact_height=options.foot_contact_height,
+        source_foot_contacts=None,
+    )
+    if analysis is None:
+        return guides, {"enabled": True, "guided_frames": 0, "reason": "missing foot joints"}
+
+    support_mask = analysis.contact_mask.any(axis=1)
+    air_segments = [
+        (start, end)
+        for start, end in _contiguous_segments(~support_mask)
+        if end - start + 1 >= 3
+    ]
+    if not air_segments:
+        return guides, {"enabled": True, "guided_frames": 0, "segments": []}
+
+    local_dirs = {side: np.zeros((frame_count, 3), dtype=np.float64) for side in ("Left", "Right")}
+    reach_ratios = {side: np.ones(frame_count, dtype=np.float64) for side in ("Left", "Right")}
+    valid = {side: np.zeros(frame_count, dtype=bool) for side in ("Left", "Right")}
+
+    for frame_index in range(frame_count):
+        source = _source_to_avatar_axes(clip.posed_joints[frame_index].astype(np.float64))
+        basis = _source_body_basis(source)
+        if basis is None:
+            continue
+        for side in ("Left", "Right"):
+            source_map = SMPL_LEG_JOINTS[side]
+            hip = source[source_map["hip"]]
+            knee = source[source_map["knee"]]
+            ankle = source[source_map["ankle"]]
+            direction = _safe_unit(ankle - hip)
+            upper = float(np.linalg.norm(knee - hip))
+            lower = float(np.linalg.norm(ankle - knee))
+            chain = upper + lower
+            if direction is None or chain < 1e-8:
+                continue
+            local_direction = _safe_unit(basis.T @ direction)
+            if local_direction is None:
+                continue
+            local_dirs[side][frame_index] = local_direction
+            reach_ratios[side][frame_index] = float(np.linalg.norm(ankle - hip) / chain)
+            valid[side][frame_index] = True
+
+    smoothed_dirs = {
+        side: _smooth_unit_vectors(local_dirs[side], valid[side], radius=2)
+        for side in ("Left", "Right")
+    }
+    strength = float(np.clip(options.airborne_leg_stabilization_strength, 0.0, 1.0))
+    guided_frames: set[int] = set()
+    segment_records: list[dict[str, int]] = []
+
+    for start, end in air_segments:
+        span = max(1, end - start)
+        segment_records.append({"start": int(start), "end": int(end)})
+        for frame_index in range(start, end + 1):
+            phase = (frame_index - start) / span
+            tuck = float(np.sin(np.pi * phase))
+            blend = strength * (0.35 + 0.65 * tuck)
+            blend *= _edge_blend_weight(
+                frame_index,
+                start,
+                end,
+                frame_count,
+                options.foot_lock_blend_frames,
+            )
+            if blend <= 0.0:
+                continue
+            frame_guides: dict[str, AirborneLegGuide] = {}
+            for side in ("Left", "Right"):
+                if not valid[side][frame_index]:
+                    continue
+                canonical_direction = _canonical_airborne_leg_direction(side, tuck)
+                direction = _safe_unit(
+                    smoothed_dirs[side][frame_index] * (1.0 - blend)
+                    + canonical_direction * blend
+                )
+                if direction is None:
+                    continue
+                canonical_reach = (1.0 - tuck) * 0.96 + tuck * options.airborne_tuck_reach_ratio
+                reach_ratio = float(
+                    reach_ratios[side][frame_index] * (1.0 - blend) + canonical_reach * blend
+                )
+                frame_guides[side] = AirborneLegGuide(
+                    direction_local=direction,
+                    reach_ratio=reach_ratio,
+                )
+            if frame_guides:
+                guides[frame_index] = frame_guides
+                guided_frames.add(frame_index)
+
+    return guides, {
+        "enabled": True,
+        "guided_frames": len(guided_frames),
+        "segments": segment_records,
+        "strength": strength,
+        "tuck_reach_ratio": options.airborne_tuck_reach_ratio,
+        "strategy": (
+            "smooth airborne leg directions in source pelvis-local space and blend them toward "
+            "a symmetric backflip tuck curve before target-rig two-bone IK"
+        ),
+    }
 
 
 def _apply_foot_contact_lock(
@@ -1123,26 +1405,60 @@ def retarget_motion_to_avatar(
 
     material_changes: dict[str, Any] = {}
     bounds: list[dict[str, list[float]]] = []
-    local_quats_by_frame: list[np.ndarray] = []
     joint_names = [joint_base_name(gltf.nodes[joint].name) for joint in skin.joints]
 
-    for frame_index in range(options.frames):
-        if options.prefer_joint_position_ik and clip.posed_joints is not None:
-            local_quats = _ik_local_quats_for_frame(clip.posed_joints[frame_index], gltf, joint_by_name)
-        else:
-            local_quats = _local_quats_for_frame(
-                clip.local_rot_mats[frame_index], joint_by_name, options=options
-            )
-            if leg_ik_enabled:
-                local_quats = _apply_calibrated_leg_ik(
-                    local=local_quats,
-                    source_joints=clip.posed_joints[frame_index],
-                    gltf=gltf,
-                    calibrations=leg_calibrations,
+    def build_local_quats_by_frame(
+        leg_guides: list[dict[str, AirborneLegGuide] | None] | None = None,
+    ) -> list[np.ndarray]:
+        quats_by_frame: list[np.ndarray] = []
+        for frame_index in range(options.frames):
+            if options.prefer_joint_position_ik and clip.posed_joints is not None:
+                local_quats = _ik_local_quats_for_frame(clip.posed_joints[frame_index], gltf, joint_by_name)
+            else:
+                local_quats = _local_quats_for_frame(
+                    clip.local_rot_mats[frame_index], joint_by_name, options=options
                 )
-        local_quats_by_frame.append(local_quats)
+                if leg_ik_enabled:
+                    local_quats = _apply_calibrated_leg_ik(
+                        local=local_quats,
+                        source_joints=clip.posed_joints[frame_index],
+                        source_global_rot_mats=clip.global_rot_mats[frame_index]
+                        if clip.global_rot_mats is not None
+                        else None,
+                        gltf=gltf,
+                        joint_by_name=joint_by_name,
+                        calibrations=leg_calibrations,
+                        body_relative=options.body_relative_leg_ik,
+                        leg_guide=leg_guides[frame_index] if leg_guides is not None else None,
+                    )
+            quats_by_frame.append(local_quats)
+        return quats_by_frame
 
-    pre_postprocess: dict[str, Any] = {"foot_orientation_lock": {"enabled": False}}
+    local_quats_by_frame = build_local_quats_by_frame()
+
+    pre_postprocess: dict[str, Any] = {
+        "airborne_leg_stabilization": {"enabled": False},
+        "foot_orientation_lock": {"enabled": False},
+    }
+    if options.airborne_leg_stabilization and leg_ik_enabled:
+        rough_frames = _build_frame_geometries(
+            gltf=gltf,
+            skin=skin,
+            local_quats_by_frame=local_quats_by_frame,
+            normalizer=normalizer,
+            clip=clip,
+            options=options,
+        )
+        leg_guides, air_report = _airborne_leg_guides(
+            clip=clip,
+            rough_frames=rough_frames,
+            joint_by_name=joint_by_name,
+            options=options,
+        )
+        pre_postprocess["airborne_leg_stabilization"] = air_report
+        if air_report.get("guided_frames", 0) > 0:
+            local_quats_by_frame = build_local_quats_by_frame(leg_guides)
+
     if options.foot_contact_lock and options.foot_orientation_lock:
         rough_frames = _build_frame_geometries(
             gltf=gltf,
@@ -1199,8 +1515,13 @@ def retarget_motion_to_avatar(
         "source_skeleton": "SMPL-22/Kimodo local rotations retargeted to avatar skin joints",
         "leg_ik": {
             "enabled": leg_ik_enabled,
-            "strategy": "calibrated two-bone IK with target-rig knee pole constraints",
+            "strategy": (
+                "body-relative calibrated two-bone IK with target-rig knee pole constraints"
+                if options.body_relative_leg_ik
+                else "calibrated two-bone IK with target-rig knee pole constraints"
+            ),
             "legs": [calibration.side for calibration in leg_calibrations],
+            "body_relative": options.body_relative_leg_ik,
         },
         "postprocess": postprocess,
     }
@@ -1218,6 +1539,7 @@ def retarget_motion_to_avatar(
         "retarget_strategy": (
             "map SMPL-22/GEM/Kimodo local rotations to compatible ViCo/Mixamo skin joints; "
             "when posed joints are available, solve calibrated two-bone leg IK using the target rig knee pole; "
+            "body-relative leg mapping and airborne leg stabilization are experimental opt-in modes; "
             "optionally stabilize root yaw and lock support feet during contact/landing"
         ),
         "selection": selection or {},

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -1,0 +1,699 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import trimesh
+from pygltflib import GLTF2
+from scipy.spatial.transform import Rotation
+
+from havln3.gltf_utils import (
+    VertexNormalizer,
+    deform_skinned_primitives,
+    identity_quaternions,
+    joint_base_name,
+    node_global_matrices,
+    write_object_config,
+)
+from havln3.materials import fix_habitat_materials
+from havln3.motion import MotionClip, SMPL22_TO_MIXAMO, resample_motion
+
+
+SMPL22_PARENTS = {
+    0: None,
+    1: 0,
+    2: 0,
+    3: 0,
+    4: 1,
+    5: 2,
+    6: 3,
+    7: 4,
+    8: 5,
+    9: 6,
+    10: 7,
+    11: 8,
+    12: 9,
+    13: 9,
+    14: 9,
+    15: 12,
+    16: 13,
+    17: 14,
+    18: 16,
+    19: 17,
+    20: 18,
+    21: 19,
+}
+
+SMPL22_CHILDREN: dict[int, list[int]] = {index: [] for index in SMPL22_TO_MIXAMO}
+for _child, _parent in SMPL22_PARENTS.items():
+    if _parent is not None:
+        SMPL22_CHILDREN[_parent].append(_child)
+
+
+SMPL_LEG_JOINTS = {
+    "Left": {"hip": 1, "knee": 4, "ankle": 7, "toe": 10},
+    "Right": {"hip": 2, "knee": 5, "ankle": 8, "toe": 11},
+}
+
+
+@dataclass(frozen=True)
+class RetargetOptions:
+    frames: int = 120
+    fps: int = 24
+    target_height: float = 1.72
+    ground_y: float = -0.2
+    rotation_scale: float = 0.65
+    lower_leg_rotation_scale: float = 0.18
+    foot_rotation_scale: float = 0.35
+    include_root_orientation: bool = True
+    preserve_root_motion: bool = False
+    root_motion_scale: float = 1.0
+    snap_to_ground: bool = True
+    alpha_cutoff: float = 0.55
+    material_roughness: float = 0.88
+    detect_texture_alpha: bool = True
+    calibrated_leg_ik: bool = True
+    prefer_joint_position_ik: bool = False
+    solidify_shell: bool = True
+    body_shell_thickness: float = 0.018
+    hair_shell_thickness: float = 0.006
+
+
+@dataclass(frozen=True)
+class LegCalibration:
+    side: str
+    hip: int
+    knee: int
+    ankle: int
+    toe: int | None
+    parent_node: int | None
+    upper_len: float
+    lower_len: float
+    rest_pole_parent_local: np.ndarray
+    rest_upper_local: np.ndarray
+    rest_lower_local: np.ndarray
+    rest_pole_hip_local: np.ndarray
+    rest_pole_knee_local: np.ndarray
+    rest_pole_foot_local: np.ndarray | None
+    rest_toe_local: np.ndarray | None
+
+
+def _scaled_quat_from_matrix(matrix: np.ndarray, scale: float) -> np.ndarray:
+    rotation = Rotation.from_matrix(matrix)
+    if scale != 1.0:
+        rotation = Rotation.from_rotvec(rotation.as_rotvec() * scale)
+    return rotation.as_quat()
+
+
+def _local_quats_for_frame(
+    frame_rot_mats: np.ndarray,
+    joint_by_name: dict[str, int],
+    *,
+    options: RetargetOptions,
+) -> np.ndarray:
+    local = identity_quaternions(len(joint_by_name))
+    for source_index, mixamo_name in SMPL22_TO_MIXAMO.items():
+        if source_index == 0 and not options.include_root_orientation:
+            continue
+        target_index = joint_by_name.get(mixamo_name)
+        if target_index is None:
+            continue
+        scale = options.rotation_scale
+        if mixamo_name in {"LeftLeg", "RightLeg"}:
+            scale = options.lower_leg_rotation_scale
+        elif mixamo_name in {"LeftFoot", "RightFoot", "LeftToeBase", "RightToeBase"}:
+            scale = options.foot_rotation_scale
+        local[target_index] = _scaled_quat_from_matrix(frame_rot_mats[source_index], scale)
+    return local
+
+
+def _rotation_from_matrix(matrix: np.ndarray) -> Rotation:
+    rotation = matrix[:3, :3].astype(np.float64)
+    norms = np.linalg.norm(rotation, axis=0)
+    rotation = rotation / np.maximum(norms, 1e-9)
+    return Rotation.from_matrix(rotation)
+
+
+def _local_rest_rotation(gltf: GLTF2, node_index: int) -> Rotation:
+    node = gltf.nodes[node_index]
+    if node.matrix is not None:
+        matrix = np.asarray(node.matrix, dtype=np.float64).reshape(4, 4).T
+        return _rotation_from_matrix(matrix)
+    return Rotation.from_quat(node.rotation or [0.0, 0.0, 0.0, 1.0])
+
+
+def _source_to_avatar_axes(points: np.ndarray) -> np.ndarray:
+    return points[:, [0, 2, 1]]
+
+
+def _safe_unit(vector: np.ndarray) -> np.ndarray | None:
+    norm = float(np.linalg.norm(vector))
+    if norm < 1e-8:
+        return None
+    return vector / norm
+
+
+def _node_parent_indices(gltf: GLTF2) -> dict[int, int]:
+    parents: dict[int, int] = {}
+    for parent_index, node in enumerate(gltf.nodes or []):
+        for child_index in node.children or []:
+            parents[child_index] = parent_index
+    return parents
+
+
+def _projected_unit(vector: np.ndarray, normal: np.ndarray) -> np.ndarray | None:
+    projected = vector - normal * float(np.dot(vector, normal))
+    return _safe_unit(projected)
+
+
+def _fallback_pole(direction: np.ndarray) -> np.ndarray:
+    candidate = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    if abs(float(np.dot(candidate, direction))) > 0.92:
+        candidate = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    pole = _projected_unit(candidate, direction)
+    if pole is None:
+        return np.array([0.0, 1.0, 0.0], dtype=np.float64)
+    return pole
+
+
+def _limb_pole(hip: np.ndarray, knee: np.ndarray, ankle: np.ndarray) -> np.ndarray:
+    line = ankle - hip
+    line_unit = _safe_unit(line)
+    if line_unit is None:
+        return np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    pole = knee - hip - line_unit * float(np.dot(knee - hip, line_unit))
+    pole_unit = _safe_unit(pole)
+    return pole_unit if pole_unit is not None else _fallback_pole(line_unit)
+
+
+def _basis_rotation(
+    rest_primary: np.ndarray,
+    rest_secondary: np.ndarray,
+    desired_primary: np.ndarray,
+    desired_secondary: np.ndarray,
+) -> Rotation:
+    rest_primary_unit = _safe_unit(rest_primary)
+    desired_primary_unit = _safe_unit(desired_primary)
+    if rest_primary_unit is None or desired_primary_unit is None:
+        return Rotation.identity()
+
+    rest_secondary_unit = _projected_unit(rest_secondary, rest_primary_unit)
+    desired_secondary_unit = _projected_unit(desired_secondary, desired_primary_unit)
+    if rest_secondary_unit is None or desired_secondary_unit is None:
+        return Rotation.align_vectors([desired_primary_unit], [rest_primary_unit])[0]
+
+    rest_basis = np.column_stack(
+        [
+            rest_primary_unit,
+            rest_secondary_unit,
+            np.cross(rest_primary_unit, rest_secondary_unit),
+        ]
+    )
+    desired_basis = np.column_stack(
+        [
+            desired_primary_unit,
+            desired_secondary_unit,
+            np.cross(desired_primary_unit, desired_secondary_unit),
+        ]
+    )
+    return Rotation.from_matrix(desired_basis @ rest_basis.T)
+
+
+def _leg_calibrations(
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    rest_globals: list[np.ndarray],
+) -> list[LegCalibration]:
+    skin = gltf.skins[0]
+    parents = _node_parent_indices(gltf)
+    rest_positions = np.stack([rest_globals[joint][:3, 3] for joint in skin.joints])
+    rest_rotations = {
+        skin_index: _rotation_from_matrix(rest_globals[node_index])
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    calibrations: list[LegCalibration] = []
+    for side in ("Left", "Right"):
+        hip = joint_by_name.get(f"{side}UpLeg")
+        knee = joint_by_name.get(f"{side}Leg")
+        ankle = joint_by_name.get(f"{side}Foot")
+        if hip is None or knee is None or ankle is None:
+            continue
+
+        toe = joint_by_name.get(f"{side}ToeBase")
+        hip_pos = rest_positions[hip]
+        knee_pos = rest_positions[knee]
+        ankle_pos = rest_positions[ankle]
+        pole = _limb_pole(hip_pos, knee_pos, ankle_pos)
+        parent_node = parents.get(skin.joints[hip])
+        parent_rot = _rotation_from_matrix(rest_globals[parent_node]) if parent_node is not None else Rotation.identity()
+
+        rest_upper = knee_pos - hip_pos
+        rest_lower = ankle_pos - knee_pos
+        calibrations.append(
+            LegCalibration(
+                side=side,
+                hip=hip,
+                knee=knee,
+                ankle=ankle,
+                toe=toe,
+                parent_node=parent_node,
+                upper_len=float(np.linalg.norm(rest_upper)),
+                lower_len=float(np.linalg.norm(rest_lower)),
+                rest_pole_parent_local=parent_rot.inv().apply(pole),
+                rest_upper_local=rest_rotations[hip].inv().apply(rest_upper),
+                rest_lower_local=rest_rotations[knee].inv().apply(rest_lower),
+                rest_pole_hip_local=rest_rotations[hip].inv().apply(pole),
+                rest_pole_knee_local=rest_rotations[knee].inv().apply(pole),
+                rest_pole_foot_local=rest_rotations[ankle].inv().apply(pole) if toe is not None else None,
+                rest_toe_local=(
+                    rest_rotations[ankle].inv().apply(rest_positions[toe] - ankle_pos)
+                    if toe is not None
+                    else None
+                ),
+            )
+        )
+    return calibrations
+
+
+def _two_bone_knee_position(
+    hip: np.ndarray,
+    direction: np.ndarray,
+    pole: np.ndarray,
+    *,
+    upper_len: float,
+    lower_len: float,
+    reach_ratio: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    chain_len = upper_len + lower_len
+    min_reach = abs(upper_len - lower_len) + 1e-5
+    max_reach = max(chain_len - 1e-5, min_reach + 1e-5)
+    reach = float(np.clip(reach_ratio * chain_len, min_reach, max_reach))
+    ankle = hip + direction * reach
+    along = (upper_len**2 - lower_len**2 + reach**2) / (2.0 * reach)
+    height = float(np.sqrt(max(upper_len**2 - along**2, 0.0)))
+    knee = hip + direction * along + pole * height
+    return knee, ankle
+
+
+def _apply_calibrated_leg_ik(
+    *,
+    local: np.ndarray,
+    source_joints: np.ndarray,
+    gltf: GLTF2,
+    calibrations: list[LegCalibration],
+) -> np.ndarray:
+    if not calibrations:
+        return local
+
+    skin = gltf.skins[0]
+    source = _source_to_avatar_axes(source_joints.astype(np.float64))
+    current_globals = node_global_matrices(gltf, local)
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    for calibration in calibrations:
+        source_map = SMPL_LEG_JOINTS[calibration.side]
+        source_hip = source[source_map["hip"]]
+        source_knee = source[source_map["knee"]]
+        source_ankle = source[source_map["ankle"]]
+        source_direction = _safe_unit(source_ankle - source_hip)
+        if source_direction is None:
+            continue
+
+        source_upper_len = float(np.linalg.norm(source_knee - source_hip))
+        source_lower_len = float(np.linalg.norm(source_ankle - source_knee))
+        source_chain_len = source_upper_len + source_lower_len
+        if source_chain_len < 1e-8:
+            continue
+        reach_ratio = float(np.linalg.norm(source_ankle - source_hip) / source_chain_len)
+
+        parent_rot = (
+            _rotation_from_matrix(current_globals[calibration.parent_node])
+            if calibration.parent_node is not None
+            else Rotation.identity()
+        )
+        pole = parent_rot.apply(calibration.rest_pole_parent_local)
+        pole = _projected_unit(pole, source_direction)
+        if pole is None:
+            source_pole = _limb_pole(source_hip, source_knee, source_ankle)
+            pole = _projected_unit(source_pole, source_direction)
+        if pole is None:
+            pole = _fallback_pole(source_direction)
+
+        hip_pos = current_globals[skin.joints[calibration.hip]][:3, 3]
+        knee_pos, ankle_pos = _two_bone_knee_position(
+            hip_pos,
+            source_direction,
+            pole,
+            upper_len=calibration.upper_len,
+            lower_len=calibration.lower_len,
+            reach_ratio=reach_ratio,
+        )
+
+        desired_upper = knee_pos - hip_pos
+        desired_lower = ankle_pos - knee_pos
+        desired_hip_rot = _basis_rotation(
+            calibration.rest_upper_local,
+            calibration.rest_pole_hip_local,
+            desired_upper,
+            pole,
+        )
+        hip_delta = local_rest_rot[calibration.hip].inv() * parent_rot.inv() * desired_hip_rot
+        local[calibration.hip] = hip_delta.as_quat()
+
+        hip_global_rot = parent_rot * local_rest_rot[calibration.hip] * hip_delta
+        desired_knee_rot = _basis_rotation(
+            calibration.rest_lower_local,
+            calibration.rest_pole_knee_local,
+            desired_lower,
+            pole,
+        )
+        knee_delta = local_rest_rot[calibration.knee].inv() * hip_global_rot.inv() * desired_knee_rot
+        local[calibration.knee] = knee_delta.as_quat()
+
+        if (
+            calibration.toe is not None
+            and calibration.rest_toe_local is not None
+            and calibration.rest_pole_foot_local is not None
+        ):
+            source_toe = source[source_map["toe"]]
+            source_toe_direction = _safe_unit(source_toe - source_ankle)
+            if source_toe_direction is not None:
+                knee_global_rot = hip_global_rot * local_rest_rot[calibration.knee] * knee_delta
+                desired_foot_rot = _basis_rotation(
+                    calibration.rest_toe_local,
+                    calibration.rest_pole_foot_local,
+                    source_toe_direction,
+                    pole,
+                )
+                foot_delta = local_rest_rot[calibration.ankle].inv() * knee_global_rot.inv() * desired_foot_rot
+                local[calibration.ankle] = foot_delta.as_quat()
+
+    return local
+
+
+def _ik_local_quats_for_frame(
+    source_joints: np.ndarray,
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+) -> np.ndarray:
+    skin = gltf.skins[0]
+    local = identity_quaternions(len(joint_by_name))
+    source = _source_to_avatar_axes(source_joints.astype(np.float64))
+
+    rest_globals = node_global_matrices(gltf, local)
+    rest_positions = np.stack([rest_globals[joint][:3, 3] for joint in skin.joints])
+    rest_global_rot = {
+        skin_index: _rotation_from_matrix(rest_globals[node_index])
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    global_rot: dict[int, Rotation] = {}
+    source_index_by_name = {name: index for index, name in SMPL22_TO_MIXAMO.items()}
+    for source_index in range(len(SMPL22_TO_MIXAMO)):
+        name = SMPL22_TO_MIXAMO[source_index]
+        skin_index = joint_by_name.get(name)
+        if skin_index is None:
+            continue
+
+        parent_source = SMPL22_PARENTS[source_index]
+        if parent_source is not None:
+            parent_name = SMPL22_TO_MIXAMO[parent_source]
+            parent_skin_index = joint_by_name.get(parent_name)
+            parent_rot = global_rot.get(parent_skin_index, Rotation.identity())
+        else:
+            parent_rot = Rotation.identity()
+
+        rest_vectors = []
+        posed_vectors = []
+        for child_source in SMPL22_CHILDREN[source_index]:
+            child_name = SMPL22_TO_MIXAMO[child_source]
+            child_skin_index = joint_by_name.get(child_name)
+            if child_skin_index is None or child_name not in source_index_by_name:
+                continue
+            rest_vector_global = rest_positions[child_skin_index] - rest_positions[skin_index]
+            rest_vector_local = rest_global_rot[skin_index].inv().apply(rest_vector_global)
+            posed_vector = source[child_source] - source[source_index]
+            rest_unit = _safe_unit(rest_vector_local)
+            posed_unit = _safe_unit(posed_vector)
+            if rest_unit is None or posed_unit is None:
+                continue
+            rest_vectors.append(rest_unit)
+            posed_vectors.append(posed_unit)
+
+        if rest_vectors:
+            desired_global, _ = Rotation.align_vectors(np.asarray(posed_vectors), np.asarray(rest_vectors))
+            delta = local_rest_rot[skin_index].inv() * parent_rot.inv() * desired_global
+            local[skin_index] = delta.as_quat()
+            global_rot[skin_index] = desired_global
+        else:
+            delta = Rotation.identity()
+            local[skin_index] = delta.as_quat()
+            global_rot[skin_index] = parent_rot * local_rest_rot[skin_index] * delta
+    return local
+
+
+def _source_geometries(avatar_glb: Path) -> list[Any]:
+    scene = trimesh.load(avatar_glb, force="scene")
+    return list(scene.geometry.values())
+
+
+def _root_offset(clip: MotionClip, frame_index: int, *, options: RetargetOptions) -> np.ndarray | None:
+    if not options.preserve_root_motion or clip.root_positions is None:
+        return None
+    raw = (clip.root_positions[frame_index] - clip.root_positions[0]) * options.root_motion_scale
+    return np.asarray(raw, dtype=np.float64)
+
+
+def _boundary_edges(faces: np.ndarray) -> np.ndarray:
+    edges = np.vstack([faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [2, 0]]])
+    sorted_edges = np.sort(edges, axis=1)
+    unique, counts = np.unique(sorted_edges, axis=0, return_counts=True)
+    return unique[counts == 1]
+
+
+def _is_hair_primitive(source: Any) -> bool:
+    names = [str(source.metadata.get("name", "")) if hasattr(source, "metadata") else ""]
+    material = getattr(getattr(source, "visual", None), "material", None)
+    if material is not None:
+        names.append(str(getattr(material, "name", "") or ""))
+    return "hair" in " ".join(names).lower()
+
+
+def _solidified_visual(source: Any, vertex_count: int) -> Any:
+    visual = source.visual.copy()
+    if hasattr(source.visual, "uv") and source.visual.uv is not None:
+        uv = np.asarray(source.visual.uv)
+        if len(uv) == vertex_count:
+            return trimesh.visual.TextureVisuals(
+                uv=np.vstack([uv, uv]),
+                material=source.visual.material,
+            )
+    return visual
+
+
+def _solidify_vertices(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    source: Any,
+    *,
+    thickness: float,
+) -> tuple[np.ndarray, np.ndarray, Any]:
+    if thickness <= 0:
+        return vertices, faces, source.visual.copy()
+
+    mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+    normals = np.asarray(mesh.vertex_normals, dtype=np.float64).copy()
+    normals /= np.linalg.norm(normals, axis=1, keepdims=True) + 1e-9
+
+    outer = vertices + normals * (thickness * 0.5)
+    inner = vertices - normals * (thickness * 0.5)
+    solid_vertices = np.vstack([outer, inner])
+    inner_offset = len(vertices)
+
+    face_sets = [faces, faces[:, ::-1] + inner_offset]
+    side_faces = []
+    for a, b in _boundary_edges(faces):
+        side_faces.append([a, b, b + inner_offset])
+        side_faces.append([a, b + inner_offset, a + inner_offset])
+    if side_faces:
+        face_sets.append(np.asarray(side_faces, dtype=np.int64))
+
+    solid_faces = np.vstack(face_sets)
+    return solid_vertices, solid_faces, _solidified_visual(source, len(vertices))
+
+
+def _export_frame(
+    glb_path: Path,
+    vertices_by_primitive: list[np.ndarray],
+    source_geometries: list[Any],
+    *,
+    options: RetargetOptions,
+) -> None:
+    scene = trimesh.Scene()
+    for primitive_index, vertices in enumerate(vertices_by_primitive):
+        if primitive_index >= len(source_geometries):
+            raise ValueError(
+                f"deformed primitive count exceeds source geometry count: {primitive_index + 1}>{len(source_geometries)}"
+            )
+        source = source_geometries[primitive_index]
+        faces = source.faces.copy()
+        thickness = (
+            options.hair_shell_thickness if _is_hair_primitive(source) else options.body_shell_thickness
+        )
+        if not options.solidify_shell:
+            thickness = 0.0
+        solid_vertices, solid_faces, visual = _solidify_vertices(
+            vertices,
+            faces,
+            source,
+            thickness=thickness,
+        )
+        mesh = trimesh.Trimesh(vertices=solid_vertices, faces=solid_faces, process=False)
+        mesh.visual = visual
+        name = source.metadata.get("name", "primitive") if hasattr(source, "metadata") else "primitive"
+        scene.add_geometry(mesh, geom_name=f"{name}_{primitive_index:02d}")
+    scene.export(glb_path, include_normals=True)
+
+
+def retarget_motion_to_avatar(
+    *,
+    avatar_glb: Path,
+    motion: MotionClip,
+    output_dir: Path,
+    asset_name: str,
+    prompt: str,
+    identity: str,
+    options: RetargetOptions | None = None,
+    selection: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    options = options or RetargetOptions()
+    clip = resample_motion(motion, options.frames)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    gltf = GLTF2().load(str(avatar_glb))
+    if not gltf.skins:
+        raise ValueError(f"avatar GLB has no skin: {avatar_glb}")
+    skin = gltf.skins[0]
+    joint_by_name = {joint_base_name(gltf.nodes[joint].name): index for index, joint in enumerate(skin.joints)}
+    source_geometries = _source_geometries(avatar_glb)
+    rest_joint_deltas = identity_quaternions(len(skin.joints))
+    rest_globals = node_global_matrices(gltf, rest_joint_deltas)
+    leg_calibrations = _leg_calibrations(gltf, joint_by_name, rest_globals)
+    leg_ik_enabled = options.calibrated_leg_ik and clip.posed_joints is not None and bool(leg_calibrations)
+
+    rest_vertices = deform_skinned_primitives(gltf, rest_joint_deltas)
+    normalizer = VertexNormalizer.from_vertices(
+        rest_vertices, target_height=options.target_height, ground_y=options.ground_y
+    )
+
+    material_changes: dict[str, Any] = {}
+    bounds: list[dict[str, list[float]]] = []
+    skeleton_frames: list[list[list[float]]] = []
+    joint_names = [joint_base_name(gltf.nodes[joint].name) for joint in skin.joints]
+
+    for frame_index in range(options.frames):
+        if options.prefer_joint_position_ik and clip.posed_joints is not None:
+            local_quats = _ik_local_quats_for_frame(clip.posed_joints[frame_index], gltf, joint_by_name)
+        else:
+            local_quats = _local_quats_for_frame(
+                clip.local_rot_mats[frame_index], joint_by_name, options=options
+            )
+            if leg_ik_enabled:
+                local_quats = _apply_calibrated_leg_ik(
+                    local=local_quats,
+                    source_joints=clip.posed_joints[frame_index],
+                    gltf=gltf,
+                    calibrations=leg_calibrations,
+                )
+        deformed = deform_skinned_primitives(gltf, local_quats)
+        globals_ = node_global_matrices(gltf, local_quats)
+        joint_points = np.stack([globals_[joint][:3, 3] for joint in skin.joints])
+        transformed, transformed_joints = normalizer.transform(
+            deformed,
+            joint_points,
+            root_offset=_root_offset(clip, frame_index, options=options),
+            snap_to_ground=options.snap_to_ground,
+        )
+        if transformed_joints is not None:
+            skeleton_frames.append(transformed_joints.tolist())
+
+        glb_path = output_dir / f"frame{frame_index:03d}.glb"
+        _export_frame(glb_path, transformed, source_geometries, options=options)
+        material_changes[glb_path.name] = fix_habitat_materials(
+            glb_path,
+            alpha_cutoff=options.alpha_cutoff,
+            roughness=options.material_roughness,
+            detect_texture_alpha=options.detect_texture_alpha,
+        )
+        write_object_config(output_dir / f"frame{frame_index:03d}.object_config.json", glb_path)
+
+        combined = np.vstack(transformed)
+        bounds.append({"min": combined.min(axis=0).tolist(), "max": combined.max(axis=0).tolist()})
+
+    skeleton = {
+        "joint_names": joint_names,
+        "frames": skeleton_frames,
+        "fps": options.fps,
+        "source_skeleton": "SMPL-22/Kimodo local rotations retargeted to avatar skin joints",
+        "leg_ik": {
+            "enabled": leg_ik_enabled,
+            "strategy": "calibrated two-bone IK with target-rig knee pole constraints",
+            "legs": [calibration.side for calibration in leg_calibrations],
+        },
+    }
+    (output_dir / "skeleton.json").write_text(json.dumps(skeleton, indent=2), encoding="utf-8")
+
+    persona = {
+        "asset_name": asset_name,
+        "identity": identity,
+        "prompt": prompt,
+        "avatar_glb": str(avatar_glb),
+        "motion_source": str(motion.source_path),
+        "frames": options.frames,
+        "fps": options.fps,
+        "appearance_strategy": "preserve original ViCo/Mixamo skinned GLB mesh, UVs, skin weights, and textures",
+        "retarget_strategy": (
+            "map SMPL-22/GEM/Kimodo local rotations to compatible ViCo/Mixamo skin joints; "
+            "when posed joints are available, solve calibrated two-bone leg IK using the target rig knee pole"
+        ),
+        "selection": selection or {},
+        "material_strategy": {
+            "hair_and_alpha_materials": "MASK",
+            "double_sided": True,
+            "roughness_min": options.material_roughness,
+            "solidify_shell": options.solidify_shell,
+            "body_shell_thickness_m": options.body_shell_thickness,
+            "hair_shell_thickness_m": options.hair_shell_thickness,
+        },
+    }
+    (output_dir / "persona.json").write_text(json.dumps(persona, indent=2), encoding="utf-8")
+    (output_dir / "habitat_material_fix_report.json").write_text(
+        json.dumps({"material_changes": material_changes}, indent=2), encoding="utf-8"
+    )
+
+    report = {
+        "asset_name": asset_name,
+        "asset_dir": str(output_dir),
+        "avatar_glb": str(avatar_glb),
+        "motion_source": str(motion.source_path),
+        "prompt": prompt,
+        "frames": options.frames,
+        "glb_count": len(list(output_dir.glob("frame*.glb"))),
+        "object_config_count": len(list(output_dir.glob("frame*.object_config.json"))),
+        "skeleton": str(output_dir / "skeleton.json"),
+        "bounds": bounds,
+        "min_ground_y": min(item["min"][1] for item in bounds),
+        "max_top_y": max(item["max"][1] for item in bounds),
+        "max_height": max(item["max"][1] - item["min"][1] for item in bounds),
+        "leg_ik": skeleton["leg_ik"],
+    }
+    return report

--- a/tests/havln3/test_avatar_action_pipeline.py
+++ b/tests/havln3/test_avatar_action_pipeline.py
@@ -60,7 +60,8 @@ def test_pipeline_exports_textured_frames_and_skeleton(tmp_path: Path) -> None:
     assert len(skeleton["frames"]) == 2
     assert len(skeleton["frames"][0]) == len(skeleton["joint_names"])
     assert skeleton["leg_ik"]["enabled"] is True
-    assert skeleton["leg_ik"]["strategy"] == "calibrated two-bone IK with target-rig knee pole constraints"
+    assert skeleton["leg_ik"]["body_relative"] is False
+    assert "two-bone IK" in skeleton["leg_ik"]["strategy"]
 
     frame = GLTF2().load(str(result.asset_dir / "frame000.glb"))
     for material in frame.materials or []:

--- a/tests/havln3/test_avatar_action_pipeline.py
+++ b/tests/havln3/test_avatar_action_pipeline.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pygltflib import GLTF2
+
+from havln3.avatar_assets import select_avatar
+from havln3.pipeline import AvatarActionPipeline, AvatarActionRequest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AVATAR_ROOT = REPO_ROOT / "vico_assets_probe" / "models"
+KIMODO_SAMPLE = (
+    REPO_ROOT
+    / "local_experiments"
+    / "kimodo_motion_backflip_wave"
+    / "office_worker_backflip_then_wave_00.npz"
+)
+
+pytestmark = pytest.mark.skipif(
+    not AVATAR_ROOT.exists() or not KIMODO_SAMPLE.exists(),
+    reason="ViCo avatar probes and Kimodo sample motion are local asset fixtures",
+)
+
+
+def test_select_avatar_allows_strong_suit_match_with_solidified_alpha_atlas() -> None:
+    match, top = select_avatar(
+        "An office worker in a suit does a backflip and waves.",
+        AVATAR_ROOT,
+    )
+
+    assert match.asset.path.name == "mixamo_Joe_Anderson.glb"
+    assert top
+    assert {"office", "suit", "formal"} <= match.asset.tags
+    assert match.asset.alpha_material_count <= 1
+
+
+def test_pipeline_exports_textured_frames_and_skeleton(tmp_path: Path) -> None:
+    result = AvatarActionPipeline().run(
+        AvatarActionRequest(
+            prompt="An office worker in a suit does a backflip and waves.",
+            output_root=tmp_path,
+            avatar_root=AVATAR_ROOT,
+            motion_npz=KIMODO_SAMPLE,
+            asset_name="test_office_backflip_wave",
+            frames=2,
+        )
+    )
+
+    assert result.asset_dir.exists()
+    assert len(list(result.asset_dir.glob("frame*.glb"))) == 2
+    assert len(list(result.asset_dir.glob("frame*.object_config.json"))) == 2
+    assert result.skeleton_path.exists()
+    assert result.report_path.exists()
+
+    skeleton = json.loads(result.skeleton_path.read_text(encoding="utf-8"))
+    assert len(skeleton["joint_names"]) >= 60
+    assert len(skeleton["frames"]) == 2
+    assert len(skeleton["frames"][0]) == len(skeleton["joint_names"])
+    assert skeleton["leg_ik"]["enabled"] is True
+    assert skeleton["leg_ik"]["strategy"] == "calibrated two-bone IK with target-rig knee pole constraints"
+
+    frame = GLTF2().load(str(result.asset_dir / "frame000.glb"))
+    for material in frame.materials or []:
+        assert material.alphaMode != "BLEND"
+        assert material.doubleSided is True
+
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    assert report["selection"]["selected"]["path"].endswith("mixamo_Joe_Anderson.glb")

--- a/tests/havln3/test_motion_generation.py
+++ b/tests/havln3/test_motion_generation.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from havln3.motion import _generated_motion_candidates
+
+
+def test_generated_motion_candidates_find_kimodo_output_directory(tmp_path) -> None:
+    output_stem = tmp_path / "clean_standing_backflip"
+    output_stem.mkdir()
+    motion_path = output_stem / "clean_standing_backflip_00.npz"
+    amass_path = output_stem / "amass_00.npz"
+    motion_path.write_bytes(b"")
+    amass_path.write_bytes(b"")
+
+    assert _generated_motion_candidates(output_stem) == [(motion_path, amass_path)]

--- a/tests/havln3/test_motion_postprocess.py
+++ b/tests/havln3/test_motion_postprocess.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import numpy as np
+
+from havln3.retarget import (
+    FrameGeometry,
+    _apply_foot_contact_lock,
+    _apply_root_yaw_stabilization,
+)
+
+
+JOINTS = {
+    "Hips": 0,
+    "LeftUpLeg": 1,
+    "RightUpLeg": 2,
+    "LeftFoot": 3,
+    "LeftToeBase": 4,
+    "RightFoot": 5,
+    "RightToeBase": 6,
+}
+
+
+def _frame(joints: np.ndarray) -> FrameGeometry:
+    vertices = joints + np.array([0.0, -0.02, 0.0])
+    return FrameGeometry(vertices_by_primitive=[vertices.copy()], joints=joints.copy())
+
+
+def test_root_yaw_stabilization_keeps_initial_horizontal_facing() -> None:
+    frames = [
+        _frame(
+            np.array(
+                [
+                    [0.0, 1.0, 0.0],
+                    [-1.0, 1.0, 0.0],
+                    [1.0, 1.0, 0.0],
+                    [-1.0, 0.0, 0.0],
+                    [-1.0, 0.0, 0.2],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.2],
+                ]
+            )
+        ),
+        _frame(
+            np.array(
+                [
+                    [0.0, 1.0, 0.0],
+                    [0.0, 1.0, -1.0],
+                    [0.0, 1.0, 1.0],
+                    [0.0, 0.0, -1.0],
+                    [0.2, 0.0, -1.0],
+                    [0.0, 0.0, 1.0],
+                    [0.2, 0.0, 1.0],
+                ]
+            )
+        ),
+    ]
+
+    report = _apply_root_yaw_stabilization(frames, JOINTS)
+    stabilized_side = frames[1].joints[JOINTS["RightUpLeg"]] - frames[1].joints[JOINTS["LeftUpLeg"]]
+
+    assert report["frames_adjusted"] == 1
+    assert stabilized_side[0] > 1.9
+    assert abs(stabilized_side[2]) < 1e-6
+
+
+def test_foot_contact_lock_anchors_landing_foot_position() -> None:
+    frames = []
+    for foot_x in (0.0, 0.1, 0.2, 0.65):
+        joints = np.array(
+            [
+                [foot_x, 1.0, 0.0],
+                [foot_x - 0.2, 0.8, 0.0],
+                [foot_x + 0.2, 0.8, 0.0],
+                [foot_x - 0.2, 0.02, 0.0],
+                [foot_x - 0.2, 0.01, 0.2],
+                [foot_x + 0.2, 0.02, 0.0],
+                [foot_x + 0.2, 0.01, 0.2],
+            ],
+            dtype=np.float64,
+        )
+        frames.append(_frame(joints))
+
+    report = _apply_foot_contact_lock(
+        frames,
+        JOINTS,
+        ground_y=0.0,
+        contact_height=0.05,
+        blend_frames=0,
+    )
+    left_toe = frames[-1].joints[JOINTS["LeftToeBase"]]
+    left_anchor = frames[0].joints[JOINTS["LeftToeBase"]]
+
+    assert report["locked_frames"] == 4
+    assert np.allclose(left_toe[[0, 2]], left_anchor[[0, 2]])
+    assert left_toe[1] >= 0.0
+    assert abs(frames[-1].vertices_by_primitive[0][:, 1].min() - 0.0) < 1e-6

--- a/tests/havln3/test_motion_postprocess.py
+++ b/tests/havln3/test_motion_postprocess.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import numpy as np
+from scipy.spatial.transform import Rotation
 
 from havln3.retarget import (
     FrameGeometry,
     _apply_foot_contact_lock,
     _apply_root_yaw_stabilization,
+    _source_body_relative_direction,
 )
 
 
@@ -94,3 +96,22 @@ def test_foot_contact_lock_anchors_landing_foot_position() -> None:
     assert np.allclose(left_toe[[0, 2]], left_anchor[[0, 2]])
     assert left_toe[1] >= 0.0
     assert abs(frames[-1].vertices_by_primitive[0][:, 1].min() - 0.0) < 1e-6
+
+
+def test_body_relative_leg_direction_follows_target_parent_frame() -> None:
+    source_parent = Rotation.from_euler("y", 90, degrees=True)
+    target_parent = Rotation.from_euler("y", -45, degrees=True)
+    source_local_leg = np.array([0.0, -1.0, 0.25], dtype=np.float64)
+    source_world_leg = source_parent.apply(source_local_leg)
+
+    mapped = _source_body_relative_direction(
+        source_world_leg,
+        source_global_rotations={0: source_parent},
+        source_parent_index=0,
+        target_parent_rotation=target_parent,
+    )
+
+    expected = target_parent.apply(source_local_leg / np.linalg.norm(source_local_leg))
+    assert mapped is not None
+    assert np.allclose(mapped, expected)
+    assert not np.allclose(mapped, source_world_leg / np.linalg.norm(source_world_leg))

--- a/tests/havln3/test_motion_quality.py
+++ b/tests/havln3/test_motion_quality.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from havln3.motion import MotionClip
+from havln3.motion_quality import MotionQualityOptions, score_motion_clip
+
+
+def _source_axes(points: np.ndarray) -> np.ndarray:
+    return points[:, [0, 2, 1]]
+
+
+def _synthetic_clip(angles: np.ndarray, *, fold_midair: bool = False) -> MotionClip:
+    frames = len(angles)
+    posed = np.zeros((frames, 22, 3), dtype=np.float64)
+    for frame_index, angle in enumerate(angles):
+        pelvis = np.array([0.0, 0.0, 1.0])
+        side = np.array([1.0, 0.0, 0.0])
+        up = np.array([0.0, np.sin(angle), np.cos(angle)])
+        forward = np.array([0.0, np.cos(angle), -np.sin(angle)])
+        posed_frame = np.zeros((22, 3), dtype=np.float64)
+        posed_frame[0] = pelvis
+        posed_frame[3] = pelvis + up * 0.25
+        posed_frame[6] = pelvis + up * 0.42
+        posed_frame[9] = pelvis + up * 0.58
+        posed_frame[15] = pelvis + up * 0.82
+        posed_frame[1] = pelvis - side * 0.11 - up * 0.05
+        posed_frame[2] = pelvis + side * 0.11 - up * 0.05
+        tuck = np.sin(np.pi * frame_index / max(frames - 1, 1))
+        for side_name, sign, hip_index, knee_index, ankle_index, toe_index in (
+            ("Left", -1.0, 1, 4, 7, 10),
+            ("Right", 1.0, 2, 5, 8, 11),
+        ):
+            del side_name
+            hip = posed_frame[hip_index]
+            if fold_midair and abs(frame_index - frames // 2) <= 1:
+                ankle = posed_frame[15] - up * 0.04 + side * sign * 0.02
+                knee = (hip + ankle) * 0.5 + forward * 0.02
+            else:
+                leg_dir = -up * (1.0 - tuck * 0.45) + forward * (tuck * 0.45)
+                leg_dir = leg_dir / np.linalg.norm(leg_dir)
+                knee = hip + leg_dir * 0.38
+                ankle = hip + leg_dir * 0.76
+            posed_frame[knee_index] = knee
+            posed_frame[ankle_index] = ankle
+            posed_frame[toe_index] = ankle + forward * 0.12
+        posed[frame_index] = _source_axes(posed_frame)
+    mats = np.tile(np.eye(3, dtype=np.float64), (frames, 22, 1, 1))
+    return MotionClip(
+        local_rot_mats=mats,
+        root_positions=np.zeros((frames, 3), dtype=np.float64),
+        posed_joints=posed,
+        foot_contacts=None,
+        source_path=Path("synthetic.npz"),
+    )
+
+
+def test_motion_quality_prefers_complete_backflip_over_partial_rotation() -> None:
+    full = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48))
+    partial = _synthetic_clip(np.concatenate([np.linspace(0.0, -1.0 * np.pi, 24), np.linspace(-1.0 * np.pi, 0.0, 24)]))
+
+    options = MotionQualityOptions(frames=48)
+    full_report = score_motion_clip(full, prompt="A person performs a clean standing backflip.", options=options)
+    partial_report = score_motion_clip(partial, prompt="A person performs a clean standing backflip.", options=options)
+
+    assert full_report.score > partial_report.score
+    assert full_report.metrics["backflip_total_degrees"] > 300
+    assert "backflip does not complete enough net rotation" in partial_report.reasons
+
+
+def test_motion_quality_penalizes_midair_body_fold() -> None:
+    clean = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48))
+    folded = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48), fold_midair=True)
+
+    options = MotionQualityOptions(frames=48)
+    clean_report = score_motion_clip(clean, prompt="A person performs a clean standing backflip.", options=options)
+    folded_report = score_motion_clip(folded, prompt="A person performs a clean standing backflip.", options=options)
+
+    assert clean_report.score > folded_report.score
+    assert folded_report.metrics["foot_head_distance_min_ratio"] < clean_report.metrics["foot_head_distance_min_ratio"]
+    assert "foot gets too close to head/face" in folded_report.reasons


### PR DESCRIPTION
Adds the havln3 text-to-avatar action asset pipeline, calibrated two-bone leg IK retargeting, HA-VLN camera render helper, documentation, and tests.\n\nValidation:\n- PYTHONPATH=src pytest tests/havln3/test_avatar_action_pipeline.py -q (skips when local asset fixtures are absent)\n- python3 -m ruff check src/havln3 scripts/generate_avatar_action.py scripts/render_avatar_action_video.py tests/havln3/test_avatar_action_pipeline.py