### PR TITLE
Add avatar action retargeting pipeline

### DIFF
--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -49,6 +49,25 @@ PYTHONPATH=src python3 scripts/generate_avatar_action.py \
   --frames 120
 ```
 
+## Motion Quality Gate
+
+Before retargeting a Kimodo/GEM batch, rank the generated candidates and only
+render the top source:
+
+```bash
+PYTHONPATH=src python3 scripts/score_kimodo_motions.py outputs/kimodo_batch \
+  --prompt "A person jogs around a small circle with natural arm swing." \
+  --frames 72 \
+  --output-json outputs/kimodo_batch/motion_quality_report.json
+```
+
+The scorer recursively scans nested Kimodo output folders. It rejects non-finite
+motions, over-tight body folds, unsafe limb/head clearances, abrupt leg changes,
+and prompt-specific failures. For running/jogging prompts it also measures
+front-back hand swing, hand spread from the torso, left/right hand alternation,
+arm-leg counterphase, and elbow bend. This catches samples where the feet move
+but the arms are held wide, locked, or synchronized with the wrong leg.
+
 ## Override Avatar Selection
 
 ```bash
@@ -111,9 +130,11 @@ stabilization, aligning the foot-up axis to the floor normal, and neutralizing
 toe-base curl. Use `--no-foot-orientation-lock` when isolating height/position
 locking from ankle twist problems.
 
-For running clips where generated arm motion looks robotic, damp the upper-arm,
-forearm, and hand channels independently with `--arm-rotation-scale`,
-`--forearm-rotation-scale`, and `--hand-rotation-scale`.
+For running clips where generated arm motion still looks robotic after sample
+selection, damp the upper-arm, forearm, and hand channels independently with
+`--arm-rotation-scale`, `--forearm-rotation-scale`, and `--hand-rotation-scale`.
+Treat this as a small cleanup pass; a source with no natural arm swing should be
+rejected by the quality gate and regenerated with a stronger prompt.
 
 ## Habitat Material And Thickness
 

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -91,21 +91,25 @@ For stationary acrobatics such as standing backflips, add:
 ```
 
 `--stabilize-root-yaw` removes unwanted horizontal spin while preserving the
-flip's pitch/roll. `--foot-contact-lock` now detects contact per foot from two
-signals: the foot must be close to the floor and its horizontal velocity must be
-small. This prevents Kimodo's noisy `foot_contacts` arrays from locking an
-entire action when the generated contact labels are nearly always true. Source
-contact labels are used only when their left/right ratios look non-degenerate;
-pass `--ignore-source-foot-contacts` to force pure geometric detection.
+flip's pitch/roll. `--foot-contact-lock` now prefers grounded foot IK when
+calibrated leg IK is available. It starts with strict geometric contacts
+(low foot height plus low horizontal velocity), rejects degenerate Kimodo
+`foot_contacts` labels, expands low-foot events into alternating gait support
+windows, then pins each support foot with the target rig's two-bone leg IK
+instead of translating the whole body.
 
-During detected contact, each foot is locked in short per-foot segments with a
-small edge blend. Tune `--foot-contact-height`, `--foot-contact-velocity`, and
-`--foot-lock-blend-frames` when a running source touches down too early or too
-late. Contact-foot orientation stabilization is enabled by default, aligning
-the toe direction to the target rig's body-facing direction, compensating for
-root yaw stabilization, aligning the foot-up axis to the floor normal, and
-neutralizing toe-base curl. Use `--no-foot-orientation-lock` when isolating
-height/position locking from ankle twist problems.
+Tune `--foot-contact-height`, `--foot-contact-velocity`,
+`--foot-support-min-frames`, `--foot-support-max-frames`,
+`--foot-support-max-air-frames`, and `--foot-lock-blend-frames` when a running
+source touches down too early, stays planted too long, or spends too many frames
+with both feet airborne. `--no-grounded-foot-ik` falls back to the older
+whole-frame contact correction for debugging only.
+
+Contact-foot orientation stabilization is enabled by default, aligning the toe
+direction to the target rig's body-facing direction, compensating for root yaw
+stabilization, aligning the foot-up axis to the floor normal, and neutralizing
+toe-base curl. Use `--no-foot-orientation-lock` when isolating height/position
+locking from ankle twist problems.
 
 For running clips where generated arm motion looks robotic, damp the upper-arm,
 forearm, and hand channels independently with `--arm-rotation-scale`,

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -136,6 +136,15 @@ selection, damp the upper-arm, forearm, and hand channels independently with
 Treat this as a small cleanup pass; a source with no natural arm swing should be
 rejected by the quality gate and regenerated with a stronger prompt.
 
+For locomotion prompts such as walking, jogging, running, or small-circle
+movement, the retargeter also enables a target-rig procedural arm swing layer by
+default. It reads the Kimodo left/right ankle forward phase, drives opposite
+arm swing from that phase, and solves the target avatar's shoulder-elbow-hand
+chain with two-bone IK so the hands stay close to the torso. This layer fixes
+source/target shoulder-axis mismatch after a good Kimodo sample has been
+selected; disable it with `--no-procedural-running-arms` when evaluating raw
+Kimodo upper-body motion.
+
 ## Habitat Material And Thickness
 
 By default each exported frame:

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -1,0 +1,125 @@
+# Avatar Action Pipeline
+
+This pipeline turns one person/action sentence into a HA-VLN/ViCo-compatible
+textured human asset:
+
+1. Select the best matching ViCo/Mixamo avatar GLB from an avatar library.
+2. Load an existing GEM/Kimodo motion output, or call `kimodo_gen`.
+3. Retarget SMPL-22/Kimodo local rotations onto the selected avatar's own skin joints.
+   When posed joints are available, legs use calibrated two-bone IK so the
+   target avatar's own knee pole controls hip-knee-ankle bending.
+4. Optionally stabilize stationary action yaw and lock support/landing feet after retargeting.
+5. Export static HAPS frames while preserving the original avatar mesh, UVs, skin weights,
+   base-color textures, and PBR materials.
+6. Add a lightweight visible shell and Habitat-safe material flags so side/back
+   cameras do not collapse thin clothing surfaces into paper-like cutouts.
+7. Write `skeleton.json`, `persona.json`, `frameXXX.glb`, and `frameXXX.object_config.json`.
+
+The key compatibility rule is: do not project a ViCo texture onto a different SMPL-X
+topology unless you explicitly want that lossy transfer. The stable path is to keep
+the original skinned avatar and drive its existing Mixamo/ViCo skeleton.
+
+Avatar selection treats large transparent texture atlases as risky for Habitat.
+A strong suit/formal match with a single alpha atlas is allowed only because the
+exporter now solidifies the mesh and forces double-sided materials; other large
+alpha avatars are heavily penalized to avoid hollow or paper-thin humans.
+
+## Existing Kimodo Motion
+
+```bash
+PYTHONPATH=src python3 scripts/generate_avatar_action.py \
+  "An office worker in a suit does a backflip and waves." \
+  --output-root outputs/demo_action \
+  --motion-npz local_experiments/kimodo_motion_backflip_wave/office_worker_backflip_then_wave_00.npz \
+  --frames 120
+```
+
+## Generate With Kimodo
+
+Run this in an environment where NVIDIA Kimodo is installed and `kimodo_gen` is on
+`PATH`:
+
+```bash
+PYTHONPATH=src python3 scripts/generate_avatar_action.py \
+  "An office worker in a suit walks forward, turns, and waves." \
+  --output-root outputs/demo_action \
+  --generator kimodo \
+  --kimodo-model Kimodo-SMPLX-RP-v1 \
+  --duration 5.0 \
+  --frames 120
+```
+
+## Override Avatar Selection
+
+```bash
+PYTHONPATH=src python3 scripts/generate_avatar_action.py \
+  "A police officer waves to the viewer." \
+  --output-root outputs/police_wave \
+  --motion-npz path/to/motion.npz \
+  --avatar-glb vico_assets_probe/models/police.glb
+```
+
+## Retarget Tuning
+
+The defaults enable calibrated two-bone leg IK when the source motion provides
+`posed_joints` such as Kimodo `.npz` outputs. The solver measures the target
+avatar bind-pose hip-knee-ankle chain, stores the target rig knee pole, then
+rebuilds each leg from the source hip-to-ankle reach while keeping the knee on
+the target rig's valid bend side.
+
+For sources without `posed_joints`, such as the current GEM `smpl_params.pt`
+loader path, the fallback deliberately damps lower-leg and foot rotations more
+than the rest of the body. This avoids backward knee bending when SMPL/GEM leg
+axes do not exactly match a ViCo/Mixamo avatar's local bone axes.
+
+Use `--rotation-scale` for the whole body, then only raise
+`--lower-leg-rotation-scale` or `--foot-rotation-scale` when the avatar rig has
+been verified to bend cleanly.
+
+Use `--no-calibrated-leg-ik` to disable the two-bone leg solver for debugging.
+
+Keep retargeting low-intrusion by default. `--body-relative-leg-ik` and
+`--airborne-leg-stabilization` are experimental opt-in tools for diagnosing a
+bad motion source, not default production fixes. If an airborne acrobatic pose
+folds the human into itself, prefer regenerating or selecting a cleaner
+Kimodo/GEM motion source over forcing a canonical tuck in post-processing.
+
+For stationary acrobatics such as standing backflips, add:
+
+```bash
+--stabilize-root-yaw --foot-contact-lock
+```
+
+`--stabilize-root-yaw` removes unwanted horizontal spin while preserving the
+flip's pitch/roll. `--foot-contact-lock` now detects contact per foot from two
+signals: the foot must be close to the floor and its horizontal velocity must be
+small. This prevents Kimodo's noisy `foot_contacts` arrays from locking an
+entire action when the generated contact labels are nearly always true. Source
+contact labels are used only when their left/right ratios look non-degenerate;
+pass `--ignore-source-foot-contacts` to force pure geometric detection.
+
+During detected contact, each foot is locked in short per-foot segments with a
+small edge blend. Tune `--foot-contact-height`, `--foot-contact-velocity`, and
+`--foot-lock-blend-frames` when a running source touches down too early or too
+late. Contact-foot orientation stabilization is enabled by default, aligning
+the toe direction to the target rig's body-facing direction, compensating for
+root yaw stabilization, aligning the foot-up axis to the floor normal, and
+neutralizing toe-base curl. Use `--no-foot-orientation-lock` when isolating
+height/position locking from ankle twist problems.
+
+For running clips where generated arm motion looks robotic, damp the upper-arm,
+forearm, and hand channels independently with `--arm-rotation-scale`,
+`--forearm-rotation-scale`, and `--hand-rotation-scale`.
+
+## Habitat Material And Thickness
+
+By default each exported frame:
+
+- converts non-hair materials to `OPAQUE`;
+- converts hair/eyelash/alpha-card materials to `MASK`;
+- sets every material `doubleSided=true`;
+- adds a symmetric mesh shell (`--body-shell-thickness`, default `0.018m`) so
+  side cameras see body volume instead of a single surface.
+
+Use `--no-solidify-shell` only for debugging source mesh deformation. In HA-VLN
+recordings, leaving the shell enabled is the safer default.

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -137,22 +137,22 @@ Treat this as a small cleanup pass; a source with no natural arm swing should be
 rejected by the quality gate and regenerated with a stronger prompt.
 
 For locomotion prompts such as walking, jogging, running, or small-circle
-movement, the retargeter also enables a target-rig procedural arm swing layer by
-default. It reads the Kimodo left/right ankle forward phase, drives opposite
-arm swing from that phase, and solves the target avatar's shoulder-elbow-hand
-chain with two-bone IK in the current chest/body basis. The default strength is
-kept low so this layer corrects shoulder-axis mismatch without replacing the
-source upper-body motion. Tune `--running-arm-swing-strength`,
-`--running-arm-forward-ratio`, `--running-arm-drop-ratio`,
-`--running-arm-side-ratio`, and the arm reach bounds for fast A/B tests; disable
-it with `--no-procedural-running-arms` when evaluating raw Kimodo upper-body
-motion.
+movement, keep the default path as raw retarget plus lower-body grounding first.
+The target-rig procedural arm swing layer is opt-in with
+`--procedural-running-arms`. It reads the Kimodo left/right ankle forward phase,
+drives opposite arm swing from that phase, and solves the target avatar's
+shoulder-elbow-hand chain with two-bone IK in the current chest/body basis.
+Tune `--running-arm-swing-strength`, `--running-arm-forward-ratio`,
+`--running-arm-drop-ratio`, `--running-arm-side-ratio`, and the arm reach bounds
+only after the source motion passes the upper-body quality gate. Use
+`--no-procedural-running-arms` to force the diagnostic baseline.
 
-The same locomotion pass can add a small spine/chest counter-rotation before
-arm cleanup. It is intentionally conservative, driven by the same left/right leg
-phase, and leaves root, pelvis, and legs untouched. Tune
-`--torso-counter-rotation-degrees` and `--torso-counter-rotation-strength`, or
-disable it with `--no-torso-counter-rotation` for baseline retarget checks.
+The same locomotion pass can add a small spine/chest counter-rotation, but this
+is also opt-in with `--torso-counter-rotation`. Keep it off while debugging foot
+contact and arm phase, because torso, arm, and foot corrections can otherwise
+fight over heading and gait timing. Tune `--torso-counter-rotation-degrees` and
+`--torso-counter-rotation-strength` only in isolated A/B tests; use
+`--no-torso-counter-rotation` to force the diagnostic baseline.
 
 ## Habitat Material And Thickness
 

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -140,10 +140,13 @@ For locomotion prompts such as walking, jogging, running, or small-circle
 movement, the retargeter also enables a target-rig procedural arm swing layer by
 default. It reads the Kimodo left/right ankle forward phase, drives opposite
 arm swing from that phase, and solves the target avatar's shoulder-elbow-hand
-chain with two-bone IK so the hands stay close to the torso. This layer fixes
-source/target shoulder-axis mismatch after a good Kimodo sample has been
-selected; disable it with `--no-procedural-running-arms` when evaluating raw
-Kimodo upper-body motion.
+chain with two-bone IK in the current chest/body basis. The default strength is
+kept low so this layer corrects shoulder-axis mismatch without replacing the
+source upper-body motion. Tune `--running-arm-swing-strength`,
+`--running-arm-forward-ratio`, `--running-arm-drop-ratio`,
+`--running-arm-side-ratio`, and the arm reach bounds for fast A/B tests; disable
+it with `--no-procedural-running-arms` when evaluating raw Kimodo upper-body
+motion.
 
 ## Habitat Material And Thickness
 

--- a/docs/avatar_action_pipeline.md
+++ b/docs/avatar_action_pipeline.md
@@ -148,6 +148,12 @@ source upper-body motion. Tune `--running-arm-swing-strength`,
 it with `--no-procedural-running-arms` when evaluating raw Kimodo upper-body
 motion.
 
+The same locomotion pass can add a small spine/chest counter-rotation before
+arm cleanup. It is intentionally conservative, driven by the same left/right leg
+phase, and leaves root, pelvis, and legs untouched. Tune
+`--torso-counter-rotation-degrees` and `--torso-counter-rotation-strength`, or
+disable it with `--no-torso-counter-rotation` for baseline retarget checks.
+
 ## Habitat Material And Thickness
 
 By default each exported frame:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,11 @@ lmdb
 msgpack_numpy
 networkx
 numpy>=1.16.1
+scipy>=1.12
+jsonschema>=4.21
+trimesh>=4.0
+pygltflib>=1.16
+pillow>=10
 pre-commit
 torch>=1.6.0
 tqdm>=4.0.0

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -112,9 +112,14 @@ def parse_args() -> argparse.Namespace:
         help="Experimental: retarget from Kimodo posed_joints by bone-direction IK.",
     )
     parser.add_argument(
+        "--procedural-running-arms",
+        action="store_true",
+        help="Enable the locomotion-specific target-rig arm swing cleanup layer.",
+    )
+    parser.add_argument(
         "--no-procedural-running-arms",
         action="store_true",
-        help="Disable the locomotion-specific target-rig arm swing cleanup layer.",
+        help="Keep the locomotion-specific target-rig arm swing cleanup layer disabled.",
     )
     parser.add_argument("--running-arm-swing-strength", type=float, default=0.35)
     parser.add_argument("--running-arm-forward-ratio", type=float, default=0.52)
@@ -123,9 +128,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--running-arm-reach-min", type=float, default=0.46)
     parser.add_argument("--running-arm-reach-max", type=float, default=0.68)
     parser.add_argument(
+        "--torso-counter-rotation",
+        action="store_true",
+        help="Enable the locomotion-specific spine/chest counter-rotation cleanup layer.",
+    )
+    parser.add_argument(
         "--no-torso-counter-rotation",
         action="store_true",
-        help="Disable the locomotion-specific spine/chest counter-rotation cleanup layer.",
+        help="Keep the locomotion-specific spine/chest counter-rotation cleanup layer disabled.",
     )
     parser.add_argument("--torso-counter-rotation-degrees", type=float, default=7.0)
     parser.add_argument("--torso-counter-rotation-strength", type=float, default=0.45)
@@ -184,14 +194,18 @@ def main() -> None:
             calibrated_leg_ik=not args.no_calibrated_leg_ik,
             body_relative_leg_ik=args.body_relative_leg_ik,
             prefer_joint_position_ik=args.joint_ik,
-            procedural_running_arm_swing=not args.no_procedural_running_arms,
+            procedural_running_arm_swing=(
+                args.procedural_running_arms and not args.no_procedural_running_arms
+            ),
             running_arm_swing_strength=args.running_arm_swing_strength,
             running_arm_forward_ratio=args.running_arm_forward_ratio,
             running_arm_drop_ratio=args.running_arm_drop_ratio,
             running_arm_side_ratio=args.running_arm_side_ratio,
             running_arm_reach_min=args.running_arm_reach_min,
             running_arm_reach_max=args.running_arm_reach_max,
-            locomotion_torso_counter_rotation=not args.no_torso_counter_rotation,
+            locomotion_torso_counter_rotation=(
+                args.torso_counter_rotation and not args.no_torso_counter_rotation
+            ),
             torso_counter_rotation_degrees=args.torso_counter_rotation_degrees,
             torso_counter_rotation_strength=args.torso_counter_rotation_strength,
             solidify_shell=not args.no_solidify_shell,

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -98,6 +98,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--airborne-leg-stabilization-strength", type=float, default=0.85)
     parser.add_argument("--airborne-tuck-reach-ratio", type=float, default=0.52)
     parser.add_argument("--no-calibrated-leg-ik", action="store_true")
+    parser.add_argument("--no-calibrated-arm-ik", action="store_true")
     parser.add_argument(
         "--body-relative-leg-ik",
         action="store_true",
@@ -192,6 +193,7 @@ def main() -> None:
             airborne_leg_stabilization_strength=args.airborne_leg_stabilization_strength,
             airborne_tuck_reach_ratio=args.airborne_tuck_reach_ratio,
             calibrated_leg_ik=not args.no_calibrated_leg_ik,
+            calibrated_arm_ik=not args.no_calibrated_arm_ik,
             body_relative_leg_ik=args.body_relative_leg_ik,
             prefer_joint_position_ik=args.joint_ik,
             procedural_running_arm_swing=(

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -116,7 +116,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Disable the locomotion-specific target-rig arm swing cleanup layer.",
     )
-    parser.add_argument("--running-arm-swing-strength", type=float, default=0.88)
+    parser.add_argument("--running-arm-swing-strength", type=float, default=0.35)
+    parser.add_argument("--running-arm-forward-ratio", type=float, default=0.52)
+    parser.add_argument("--running-arm-drop-ratio", type=float, default=0.50)
+    parser.add_argument("--running-arm-side-ratio", type=float, default=0.055)
+    parser.add_argument("--running-arm-reach-min", type=float, default=0.46)
+    parser.add_argument("--running-arm-reach-max", type=float, default=0.68)
     return parser.parse_args()
 
 
@@ -174,6 +179,11 @@ def main() -> None:
             prefer_joint_position_ik=args.joint_ik,
             procedural_running_arm_swing=not args.no_procedural_running_arms,
             running_arm_swing_strength=args.running_arm_swing_strength,
+            running_arm_forward_ratio=args.running_arm_forward_ratio,
+            running_arm_drop_ratio=args.running_arm_drop_ratio,
+            running_arm_side_ratio=args.running_arm_side_ratio,
+            running_arm_reach_min=args.running_arm_reach_min,
+            running_arm_reach_max=args.running_arm_reach_max,
             solidify_shell=not args.no_solidify_shell,
             body_shell_thickness=args.body_shell_thickness,
             hair_shell_thickness=args.hair_shell_thickness,

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -111,6 +111,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Experimental: retarget from Kimodo posed_joints by bone-direction IK.",
     )
+    parser.add_argument(
+        "--no-procedural-running-arms",
+        action="store_true",
+        help="Disable the locomotion-specific target-rig arm swing cleanup layer.",
+    )
+    parser.add_argument("--running-arm-swing-strength", type=float, default=0.88)
     return parser.parse_args()
 
 
@@ -166,6 +172,8 @@ def main() -> None:
             calibrated_leg_ik=not args.no_calibrated_leg_ik,
             body_relative_leg_ik=args.body_relative_leg_ik,
             prefer_joint_position_ik=args.joint_ik,
+            procedural_running_arm_swing=not args.no_procedural_running_arms,
+            running_arm_swing_strength=args.running_arm_swing_strength,
             solidify_shell=not args.no_solidify_shell,
             body_shell_thickness=args.body_shell_thickness,
             hair_shell_thickness=args.hair_shell_thickness,

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -122,6 +122,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--running-arm-side-ratio", type=float, default=0.055)
     parser.add_argument("--running-arm-reach-min", type=float, default=0.46)
     parser.add_argument("--running-arm-reach-max", type=float, default=0.68)
+    parser.add_argument(
+        "--no-torso-counter-rotation",
+        action="store_true",
+        help="Disable the locomotion-specific spine/chest counter-rotation cleanup layer.",
+    )
+    parser.add_argument("--torso-counter-rotation-degrees", type=float, default=7.0)
+    parser.add_argument("--torso-counter-rotation-strength", type=float, default=0.45)
     return parser.parse_args()
 
 
@@ -184,6 +191,9 @@ def main() -> None:
             running_arm_side_ratio=args.running_arm_side_ratio,
             running_arm_reach_min=args.running_arm_reach_min,
             running_arm_reach_max=args.running_arm_reach_max,
+            locomotion_torso_counter_rotation=not args.no_torso_counter_rotation,
+            torso_counter_rotation_degrees=args.torso_counter_rotation_degrees,
+            torso_counter_rotation_strength=args.torso_counter_rotation_strength,
             solidify_shell=not args.no_solidify_shell,
             body_shell_thickness=args.body_shell_thickness,
             hair_shell_thickness=args.hair_shell_thickness,

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from havln3.pipeline import AvatarActionPipeline, AvatarActionRequest  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a textured HA-VLN/ViCo human action asset from one sentence."
+    )
+    parser.add_argument("prompt", help="One-sentence person/action description.")
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--avatar-root", type=Path, default=Path("vico_assets_probe/models"))
+    parser.add_argument("--avatar-glb", type=Path)
+    parser.add_argument("--avatar-catalog", type=Path)
+    parser.add_argument("--motion-npz", type=Path, help="Existing Kimodo .npz output.")
+    parser.add_argument("--amass-npz", type=Path, help="Optional AMASS .npz companion file.")
+    parser.add_argument("--gem-smpl-params", type=Path, help="Existing GEM smpl_params.pt file.")
+    parser.add_argument("--gem-param-group", default="body_params_global")
+    parser.add_argument("--generator", choices=["existing", "kimodo"], default="existing")
+    parser.add_argument("--kimodo-model", default="Kimodo-SMPLX-RP-v1")
+    parser.add_argument("--kimodo-num-samples", type=int, default=1)
+    parser.add_argument(
+        "--no-motion-quality-select",
+        action="store_true",
+        help="Disable automatic quality ranking when Kimodo generates multiple samples.",
+    )
+    parser.add_argument("--motion-quality-min-score", type=float, default=62.0)
+    parser.add_argument("--duration", type=float, default=5.0)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--asset-name")
+    parser.add_argument("--identity")
+    parser.add_argument("--frames", type=int, default=120)
+    parser.add_argument("--fps", type=int, default=24)
+    parser.add_argument("--target-height", type=float, default=1.72)
+    parser.add_argument("--ground-y", type=float, default=-0.2)
+    parser.add_argument("--rotation-scale", type=float, default=0.65)
+    parser.add_argument("--arm-rotation-scale", type=float, default=0.65)
+    parser.add_argument("--forearm-rotation-scale", type=float, default=0.45)
+    parser.add_argument("--hand-rotation-scale", type=float, default=0.18)
+    parser.add_argument("--lower-leg-rotation-scale", type=float, default=0.18)
+    parser.add_argument("--foot-rotation-scale", type=float, default=0.35)
+    parser.add_argument("--no-root-orientation", action="store_true")
+    parser.add_argument("--preserve-root-motion", action="store_true")
+    parser.add_argument("--root-motion-scale", type=float, default=1.0)
+    parser.add_argument(
+        "--stabilize-root-yaw",
+        action="store_true",
+        help="Post-process stationary flips/poses so the avatar keeps its initial horizontal facing.",
+    )
+    parser.add_argument(
+        "--foot-contact-lock",
+        action="store_true",
+        help="Post-process support/landing frames so low feet stay anchored to the floor.",
+    )
+    parser.add_argument(
+        "--no-foot-orientation-lock",
+        action="store_true",
+        help="Disable contact-foot orientation stabilization when --foot-contact-lock is enabled.",
+    )
+    parser.add_argument("--foot-contact-height", type=float, default=0.12)
+    parser.add_argument(
+        "--foot-contact-velocity",
+        type=float,
+        default=0.02,
+        help="Maximum per-frame horizontal foot speed for detected contact frames.",
+    )
+    parser.add_argument(
+        "--ignore-source-foot-contacts",
+        action="store_true",
+        help="Use only geometric contact detection instead of Kimodo's foot contact labels.",
+    )
+    parser.add_argument("--foot-lock-blend-frames", type=int, default=4)
+    parser.add_argument(
+        "--airborne-leg-stabilization",
+        action="store_true",
+        help="Experimental: stabilize airborne acrobatic leg motion in pelvis-local space before leg IK.",
+    )
+    parser.add_argument("--airborne-leg-stabilization-strength", type=float, default=0.85)
+    parser.add_argument("--airborne-tuck-reach-ratio", type=float, default=0.52)
+    parser.add_argument("--no-calibrated-leg-ik", action="store_true")
+    parser.add_argument(
+        "--body-relative-leg-ik",
+        action="store_true",
+        help="Experimental: map Kimodo leg directions through pelvis-local frames before leg IK.",
+    )
+    parser.add_argument("--no-solidify-shell", action="store_true")
+    parser.add_argument("--body-shell-thickness", type=float, default=0.018)
+    parser.add_argument("--hair-shell-thickness", type=float, default=0.006)
+    parser.add_argument(
+        "--joint-ik",
+        action="store_true",
+        help="Experimental: retarget from Kimodo posed_joints by bone-direction IK.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = AvatarActionPipeline().run(
+        AvatarActionRequest(
+            prompt=args.prompt,
+            output_root=args.output_root,
+            avatar_root=args.avatar_root,
+            avatar_glb=args.avatar_glb,
+            avatar_catalog=args.avatar_catalog,
+            motion_npz=args.motion_npz,
+            amass_npz=args.amass_npz,
+            gem_smpl_params=args.gem_smpl_params,
+            gem_param_group=args.gem_param_group,
+            generator=args.generator,
+            kimodo_model=args.kimodo_model,
+            kimodo_num_samples=args.kimodo_num_samples,
+            motion_quality_select=not args.no_motion_quality_select,
+            motion_quality_min_score=args.motion_quality_min_score,
+            duration=args.duration,
+            seed=args.seed,
+            asset_name=args.asset_name,
+            identity=args.identity,
+            frames=args.frames,
+            fps=args.fps,
+            target_height=args.target_height,
+            ground_y=args.ground_y,
+            rotation_scale=args.rotation_scale,
+            arm_rotation_scale=args.arm_rotation_scale,
+            forearm_rotation_scale=args.forearm_rotation_scale,
+            hand_rotation_scale=args.hand_rotation_scale,
+            lower_leg_rotation_scale=args.lower_leg_rotation_scale,
+            foot_rotation_scale=args.foot_rotation_scale,
+            include_root_orientation=not args.no_root_orientation,
+            preserve_root_motion=args.preserve_root_motion,
+            root_motion_scale=args.root_motion_scale,
+            stabilize_root_yaw=args.stabilize_root_yaw,
+            foot_contact_lock=args.foot_contact_lock,
+            foot_orientation_lock=not args.no_foot_orientation_lock,
+            foot_contact_height=args.foot_contact_height,
+            foot_contact_velocity=args.foot_contact_velocity,
+            foot_contact_use_source=not args.ignore_source_foot_contacts,
+            foot_lock_blend_frames=args.foot_lock_blend_frames,
+            airborne_leg_stabilization=args.airborne_leg_stabilization,
+            airborne_leg_stabilization_strength=args.airborne_leg_stabilization_strength,
+            airborne_tuck_reach_ratio=args.airborne_tuck_reach_ratio,
+            calibrated_leg_ik=not args.no_calibrated_leg_ik,
+            body_relative_leg_ik=args.body_relative_leg_ik,
+            prefer_joint_position_ik=args.joint_ik,
+            solidify_shell=not args.no_solidify_shell,
+            body_shell_thickness=args.body_shell_thickness,
+            hair_shell_thickness=args.hair_shell_thickness,
+        )
+    )
+    print(
+        json.dumps(
+            {
+                "asset_name": result.asset_name,
+                "asset_dir": str(result.asset_dir),
+                "avatar_glb": str(result.avatar_glb),
+                "motion_path": str(result.motion_path),
+                "report_path": str(result.report_path),
+                "skeleton_path": str(result.skeleton_path),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_avatar_action.py
+++ b/scripts/generate_avatar_action.py
@@ -83,6 +83,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--foot-lock-blend-frames", type=int, default=4)
     parser.add_argument(
+        "--no-grounded-foot-ik",
+        action="store_true",
+        help="Use legacy whole-frame contact correction instead of per-foot two-bone IK targets.",
+    )
+    parser.add_argument("--foot-support-min-frames", type=int, default=8)
+    parser.add_argument("--foot-support-max-frames", type=int, default=16)
+    parser.add_argument("--foot-support-max-air-frames", type=int, default=8)
+    parser.add_argument(
         "--airborne-leg-stabilization",
         action="store_true",
         help="Experimental: stabilize airborne acrobatic leg motion in pelvis-local space before leg IK.",
@@ -148,6 +156,10 @@ def main() -> None:
             foot_contact_velocity=args.foot_contact_velocity,
             foot_contact_use_source=not args.ignore_source_foot_contacts,
             foot_lock_blend_frames=args.foot_lock_blend_frames,
+            grounded_foot_ik=not args.no_grounded_foot_ik,
+            foot_support_min_frames=args.foot_support_min_frames,
+            foot_support_max_frames=args.foot_support_max_frames,
+            foot_support_max_air_frames=args.foot_support_max_air_frames,
             airborne_leg_stabilization=args.airborne_leg_stabilization,
             airborne_leg_stabilization_strength=args.airborne_leg_stabilization_strength,
             airborne_tuck_reach_ratio=args.airborne_tuck_reach_ratio,

--- a/scripts/score_kimodo_motions.py
+++ b/scripts/score_kimodo_motions.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from havln3.motion_quality import MotionQualityOptions, rank_motion_files  # noqa: E402
+
+
+def is_motion_candidate(path: Path) -> bool:
+    return path.suffix in {".npz", ".pt"} and not path.stem.startswith("amass_") and not path.stem.endswith("_amass")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Rank Kimodo/GEM motion samples before retargeting.")
+    parser.add_argument("paths", nargs="+", type=Path, help="Motion .npz/.pt files or directories.")
+    parser.add_argument("--prompt", default="", help="Action prompt used for semantic checks such as backflip.")
+    parser.add_argument("--frames", type=int, default=60)
+    parser.add_argument("--min-score", type=float, default=62.0)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--gem-param-group", default="body_params_global")
+    return parser.parse_args()
+
+
+def expand_paths(paths: list[Path]) -> list[Path]:
+    expanded: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            expanded.extend(sorted(path.glob("*.npz")))
+            expanded.extend(sorted(path.glob("*.pt")))
+            expanded.extend(sorted(path.glob("*/*.npz")))
+            expanded.extend(sorted(path.glob("*/*.pt")))
+        else:
+            expanded.extend(sorted(path.parent.glob(path.name)) if any(ch in path.name for ch in "*?[]") else [path])
+    return [path for path in expanded if path.exists() and is_motion_candidate(path)]
+
+
+def main() -> None:
+    args = parse_args()
+    paths = expand_paths(args.paths)
+    if not paths:
+        raise SystemExit("No existing motion files matched.")
+    reports = rank_motion_files(
+        paths,
+        prompt=args.prompt,
+        options=MotionQualityOptions(frames=args.frames, min_score=args.min_score),
+        gem_param_group=args.gem_param_group,
+    )
+    payload = {
+        "selected": reports[0].to_dict(),
+        "candidates": [report.to_dict() for report in reports],
+    }
+    text = json.dumps(payload, indent=2)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(text, encoding="utf-8")
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_kimodo_motions.py
+++ b/scripts/score_kimodo_motions.py
@@ -34,10 +34,8 @@ def expand_paths(paths: list[Path]) -> list[Path]:
     expanded: list[Path] = []
     for path in paths:
         if path.is_dir():
-            expanded.extend(sorted(path.glob("*.npz")))
-            expanded.extend(sorted(path.glob("*.pt")))
-            expanded.extend(sorted(path.glob("*/*.npz")))
-            expanded.extend(sorted(path.glob("*/*.pt")))
+            expanded.extend(sorted(path.rglob("*.npz")))
+            expanded.extend(sorted(path.rglob("*.pt")))
         else:
             expanded.extend(sorted(path.parent.glob(path.name)) if any(ch in path.name for ch in "*?[]") else [path])
     return [path for path in expanded if path.exists() and is_motion_candidate(path)]

--- a/src/havln3/__init__.py
+++ b/src/havln3/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for generating textured human action assets for HA-VLN/ViCo."""
+
+from havln3.pipeline import AvatarActionPipeline, AvatarActionRequest, AvatarActionResult
+
+__all__ = ["AvatarActionPipeline", "AvatarActionRequest", "AvatarActionResult"]

--- a/src/havln3/avatar_assets.py
+++ b/src/havln3/avatar_assets.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import re
+import base64
+import io
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from pygltflib import GLTF2
+
+_FEMALE_NAMES = {
+    "clara",
+    "elena",
+    "elizabeth",
+    "emily",
+    "erika",
+    "eve",
+    "freya",
+    "ivy",
+    "jody",
+    "kate",
+    "layla",
+    "louise",
+    "megan",
+    "mira",
+    "naomi",
+    "olivia",
+    "scarlett",
+    "shannon",
+    "sophia",
+    "sophie",
+    "yara",
+    "zara",
+}
+
+_MALE_NAMES = {
+    "adam",
+    "adrian",
+    "alex",
+    "brian",
+    "brycer",
+    "chad",
+    "dylan",
+    "elliot",
+    "ethan",
+    "felix",
+    "james",
+    "joe",
+    "julian",
+    "kenji",
+    "leonard",
+    "liam",
+    "malik",
+    "marco",
+    "marcus",
+    "morten",
+    "nico",
+    "rafael",
+    "roth",
+    "steve",
+    "tariq",
+    "theo",
+    "victor",
+    "walter",
+    "zane",
+}
+
+_DEFAULT_TAGS_BY_STEM = {
+    "mixamo_joe_anderson": {"male", "office", "business", "suit", "formal"},
+    "mixamo_james_thompson": {"male", "office", "business", "formal"},
+    "mixamo_steve_johnson": {"male", "casual", "office"},
+    "mixamo_brian_carter": {"male", "casual"},
+    "mixamo_alex_jefferson": {"male", "casual"},
+    "mixamo_roth_miller": {"male", "casual"},
+    "mixamo_chad_thompson": {"male", "casual"},
+    "police": {"male", "police", "uniform", "officer"},
+    "male_1": {"male", "generic"},
+    "mixamo_female_1_decimated": {"female", "generic"},
+}
+
+_PROMPT_SYNONYMS = {
+    "man": {"male"},
+    "male": {"male"},
+    "boy": {"male"},
+    "gentleman": {"male"},
+    "男人": {"male"},
+    "男性": {"male"},
+    "男": {"male"},
+    "woman": {"female"},
+    "female": {"female"},
+    "girl": {"female"},
+    "lady": {"female"},
+    "女士": {"female"},
+    "女人": {"female"},
+    "女性": {"female"},
+    "女": {"female"},
+    "office": {"office", "business"},
+    "business": {"business", "office"},
+    "suit": {"suit", "formal"},
+    "formal": {"formal", "suit"},
+    "worker": {"office"},
+    "西装": {"suit", "formal"},
+    "办公室": {"office", "business"},
+    "商务": {"business", "formal"},
+    "警察": {"police", "officer", "uniform"},
+    "police": {"police", "officer", "uniform"},
+    "officer": {"police", "officer", "uniform"},
+    "uniform": {"uniform"},
+}
+
+
+def _tokenize(text: str) -> set[str]:
+    words = set(re.findall(r"[a-z0-9]+", text.lower()))
+    for phrase, tags in _PROMPT_SYNONYMS.items():
+        if phrase in text.lower():
+            words.update(tags)
+    return words
+
+
+def _display_name_from_stem(stem: str) -> str:
+    clean = stem
+    for prefix in ("mixamo_", "custom_"):
+        if clean.startswith(prefix):
+            clean = clean[len(prefix) :]
+            break
+    clean = clean.replace("_merge", "").replace("_decimated", "")
+    clean = clean.replace("_", " ").replace(".glb", "")
+    return " ".join(part.capitalize() for part in clean.split())
+
+
+@dataclass(frozen=True)
+class AvatarAsset:
+    path: Path
+    display_name: str
+    provider: str
+    tags: set[str] = field(default_factory=set)
+    max_alpha_fraction: float = 0.0
+    alpha_material_count: int = 0
+
+    @property
+    def stem_key(self) -> str:
+        return self.path.stem.lower()
+
+    @property
+    def tokens(self) -> set[str]:
+        return _tokenize(f"{self.display_name} {self.path.stem} {' '.join(sorted(self.tags))}")
+
+
+@dataclass(frozen=True)
+class AvatarMatch:
+    asset: AvatarAsset
+    score: float
+    reasons: tuple[str, ...]
+
+
+def _image_bytes(gltf: GLTF2, image_index: int, glb_path: Path) -> bytes | None:
+    image = gltf.images[image_index]
+    if image.bufferView is not None:
+        view = gltf.bufferViews[image.bufferView]
+        blob = gltf.binary_blob()
+        start = int(view.byteOffset or 0)
+        return bytes(blob[start : start + int(view.byteLength or 0)])
+    if image.uri:
+        if image.uri.startswith("data:"):
+            return base64.b64decode(image.uri.split(",", 1)[1])
+        image_path = glb_path.parent / image.uri
+        if image_path.exists():
+            return image_path.read_bytes()
+    return None
+
+
+def _alpha_profile(path: Path) -> tuple[float, int]:
+    try:
+        gltf = GLTF2().load(str(path))
+    except Exception:
+        return 1.0, 1
+
+    fractions: list[float] = []
+    for material in gltf.materials or []:
+        pbr = material.pbrMetallicRoughness
+        if not pbr or not pbr.baseColorTexture:
+            continue
+        texture = gltf.textures[pbr.baseColorTexture.index]
+        if texture.source is None:
+            continue
+        raw = _image_bytes(gltf, texture.source, path)
+        if not raw:
+            continue
+        try:
+            with Image.open(io.BytesIO(raw)) as image:
+                alpha = np.asarray(image.convert("RGBA"))[:, :, 3]
+                fractions.append(float((alpha < 250).mean()))
+        except Exception:
+            continue
+    return (max(fractions) if fractions else 0.0, sum(fraction > 0.05 for fraction in fractions))
+
+
+def _asset_from_path(path: Path, catalog: dict[str, Any] | None = None) -> AvatarAsset:
+    stem = path.stem.lower()
+    provider = "mixamo" if stem.startswith("mixamo_") else "custom" if stem.startswith("custom_") else "local"
+    display_name = _display_name_from_stem(path.stem)
+    tags = set(_DEFAULT_TAGS_BY_STEM.get(stem, set()))
+    tokens = _tokenize(display_name)
+    if tokens & _FEMALE_NAMES:
+        tags.add("female")
+    if tokens & _MALE_NAMES:
+        tags.add("male")
+    tags.update(tokens - _FEMALE_NAMES - _MALE_NAMES)
+
+    if catalog:
+        override = catalog.get(path.name) or catalog.get(path.stem) or catalog.get(str(path))
+        if isinstance(override, dict):
+            display_name = str(override.get("display_name") or display_name)
+            tags.update(str(tag).lower() for tag in override.get("tags", []))
+            provider = str(override.get("provider") or provider)
+
+    max_alpha, alpha_count = _alpha_profile(path)
+    return AvatarAsset(
+        path=path,
+        display_name=display_name,
+        provider=provider,
+        tags=tags,
+        max_alpha_fraction=max_alpha,
+        alpha_material_count=alpha_count,
+    )
+
+
+def load_avatar_catalog(catalog_path: Path | None) -> dict[str, Any]:
+    if not catalog_path:
+        return {}
+    if not catalog_path.exists():
+        raise FileNotFoundError(f"avatar catalog does not exist: {catalog_path}")
+    data = json.loads(catalog_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"avatar catalog must be a JSON object: {catalog_path}")
+    return data
+
+
+def build_avatar_index(avatar_root: Path, catalog_path: Path | None = None) -> list[AvatarAsset]:
+    catalog = load_avatar_catalog(catalog_path)
+    assets = [_asset_from_path(path, catalog) for path in sorted(avatar_root.glob("*.glb"))]
+    if not assets:
+        raise FileNotFoundError(f"no .glb avatars found under {avatar_root}")
+    return assets
+
+
+def score_avatar(prompt: str, asset: AvatarAsset) -> AvatarMatch:
+    prompt_tokens = _tokenize(prompt)
+    asset_tokens = asset.tokens
+    overlap = prompt_tokens & asset_tokens
+
+    score = float(len(overlap) * 8)
+    reasons: list[str] = []
+    if overlap:
+        reasons.append(f"matched tokens: {', '.join(sorted(overlap)[:8])}")
+
+    display_lower = asset.display_name.lower()
+    if display_lower and display_lower in prompt.lower():
+        score += 80
+        reasons.append(f"explicit name match: {asset.display_name}")
+
+    if "male" in prompt_tokens or "female" in prompt_tokens:
+        wanted = "female" if "female" in prompt_tokens else "male"
+        if wanted in asset.tags:
+            score += 30
+            reasons.append(f"gender tag: {wanted}")
+        elif {"male", "female"} & asset.tags:
+            score -= 25
+
+    for tag in ("police", "office", "business", "suit", "uniform", "formal"):
+        if tag in prompt_tokens and tag in asset.tags:
+            score += 20
+            reasons.append(f"appearance tag: {tag}")
+
+    if asset.provider == "mixamo":
+        score += 8
+        reasons.append("Mixamo/ViCo skeleton compatibility")
+    has_strong_suit_match = bool({"suit", "formal"} & prompt_tokens & asset.tags)
+    if asset.max_alpha_fraction > 0.5 and has_strong_suit_match and asset.alpha_material_count <= 1:
+        score -= 5
+        reasons.append(f"single alpha atlas allowed with solidified shell: {asset.max_alpha_fraction:.2f}")
+    elif asset.max_alpha_fraction > 0.5:
+        score -= 120
+        reasons.append(f"large transparent texture area unsafe for Habitat: {asset.max_alpha_fraction:.2f}")
+    elif asset.max_alpha_fraction > 0.1:
+        score -= 45
+        reasons.append(f"moderate transparent texture area: {asset.max_alpha_fraction:.2f}")
+    elif asset.alpha_material_count == 0:
+        score += 12
+        reasons.append("opaque material profile")
+    if "merge" in asset.path.stem.lower():
+        score -= 6
+    if "decimated" in asset.path.stem.lower():
+        score -= 4
+    if "generic" in asset.tags:
+        score -= 3
+
+    if not reasons:
+        reasons.append("fallback best available humanoid GLB")
+    return AvatarMatch(asset=asset, score=score, reasons=tuple(reasons))
+
+
+def select_avatar(
+    prompt: str,
+    avatar_root: Path,
+    *,
+    preferred_avatar: Path | None = None,
+    catalog_path: Path | None = None,
+) -> tuple[AvatarMatch, list[AvatarMatch]]:
+    if preferred_avatar:
+        asset = _asset_from_path(preferred_avatar, load_avatar_catalog(catalog_path))
+        return AvatarMatch(asset=asset, score=float("inf"), reasons=("explicit avatar path",)), []
+
+    matches = [score_avatar(prompt, asset) for asset in build_avatar_index(avatar_root, catalog_path)]
+    matches.sort(key=lambda item: (item.score, item.asset.provider == "mixamo"), reverse=True)
+    return matches[0], matches[:5]

--- a/src/havln3/gltf_utils.py
+++ b/src/havln3/gltf_utils.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pygltflib import GLTF2
+from scipy.spatial.transform import Rotation
+
+
+_COMPONENT_DTYPES = {
+    5120: np.int8,
+    5121: np.uint8,
+    5122: np.int16,
+    5123: np.uint16,
+    5125: np.uint32,
+    5126: np.float32,
+}
+_TYPE_COUNTS = {
+    "SCALAR": 1,
+    "VEC2": 2,
+    "VEC3": 3,
+    "VEC4": 4,
+    "MAT2": 4,
+    "MAT3": 9,
+    "MAT4": 16,
+}
+
+
+def joint_base_name(name: str | None) -> str:
+    if not name:
+        return ""
+    return name.split(":")[-1].split("|")[-1].strip()
+
+
+def read_accessor(gltf: GLTF2, accessor_index: int | None) -> np.ndarray:
+    if accessor_index is None:
+        raise ValueError("missing accessor index")
+    accessor = gltf.accessors[accessor_index]
+    if accessor.bufferView is None:
+        raise ValueError(f"accessor {accessor_index} has no bufferView")
+    buffer_view = gltf.bufferViews[accessor.bufferView]
+    dtype = np.dtype(_COMPONENT_DTYPES[accessor.componentType]).newbyteorder("<")
+    components = _TYPE_COUNTS[accessor.type]
+    blob = gltf.binary_blob()
+    offset = int(buffer_view.byteOffset or 0) + int(accessor.byteOffset or 0)
+    count = int(accessor.count)
+    stride = int(buffer_view.byteStride or 0)
+
+    if stride and stride != dtype.itemsize * components:
+        rows = []
+        for row_index in range(count):
+            row_offset = offset + row_index * stride
+            rows.append(np.frombuffer(blob, dtype=dtype, count=components, offset=row_offset))
+        array = np.vstack(rows)
+    else:
+        array = np.frombuffer(blob, dtype=dtype, count=count * components, offset=offset)
+        array = array.reshape(count, components)
+
+    if accessor.normalized and np.issubdtype(array.dtype, np.integer):
+        if np.issubdtype(array.dtype, np.signedinteger):
+            max_value = float(np.iinfo(array.dtype).max)
+            array = np.maximum(array.astype(np.float64) / max_value, -1.0)
+        else:
+            max_value = float(np.iinfo(array.dtype).max)
+            array = array.astype(np.float64) / max_value
+    return array.copy()
+
+
+def _node_matrix(node: Any, rotation_delta: np.ndarray | None = None) -> np.ndarray:
+    if node.matrix is not None:
+        matrix = np.asarray(node.matrix, dtype=np.float64).reshape(4, 4).T
+        if rotation_delta is not None:
+            delta = np.eye(4, dtype=np.float64)
+            delta[:3, :3] = Rotation.from_quat(rotation_delta).as_matrix()
+            matrix = matrix @ delta
+        return matrix
+
+    translation = np.asarray(node.translation or [0.0, 0.0, 0.0], dtype=np.float64)
+    rotation = np.asarray(node.rotation or [0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    if rotation_delta is not None:
+        rotation = (Rotation.from_quat(rotation) * Rotation.from_quat(rotation_delta)).as_quat()
+    scale = np.asarray(node.scale or [1.0, 1.0, 1.0], dtype=np.float64)
+
+    matrix = np.eye(4, dtype=np.float64)
+    matrix[:3, :3] = Rotation.from_quat(rotation).as_matrix() @ np.diag(scale)
+    matrix[:3, 3] = translation
+    return matrix
+
+
+def node_global_matrices(gltf: GLTF2, local_joint_deltas: np.ndarray | None = None) -> list[np.ndarray]:
+    skin = gltf.skins[0] if gltf.skins else None
+    joint_to_skin_index = {}
+    if skin is not None:
+        joint_to_skin_index = {joint: index for index, joint in enumerate(skin.joints or [])}
+
+    globals_: list[np.ndarray | None] = [None] * len(gltf.nodes)
+
+    def local_matrix(node_index: int) -> np.ndarray:
+        skin_index = joint_to_skin_index.get(node_index)
+        delta = None
+        if skin_index is not None and local_joint_deltas is not None:
+            delta = local_joint_deltas[skin_index]
+        return _node_matrix(gltf.nodes[node_index], delta)
+
+    def visit(node_index: int, parent: np.ndarray) -> None:
+        current = parent @ local_matrix(node_index)
+        globals_[node_index] = current
+        for child in gltf.nodes[node_index].children or []:
+            visit(child, current)
+
+    scene_indices = gltf.scene
+    scenes = [gltf.scenes[scene_indices]] if scene_indices is not None and gltf.scenes else gltf.scenes or []
+    for scene in scenes:
+        for root in scene.nodes or []:
+            visit(root, np.eye(4, dtype=np.float64))
+    for index, matrix in enumerate(globals_):
+        if matrix is None:
+            visit(index, np.eye(4, dtype=np.float64))
+    return [matrix if matrix is not None else np.eye(4, dtype=np.float64) for matrix in globals_]
+
+
+def deform_skinned_primitives(gltf: GLTF2, local_joint_deltas: np.ndarray) -> list[np.ndarray]:
+    if not gltf.skins:
+        raise ValueError("avatar GLB has no skin")
+    skin = gltf.skins[0]
+    inverse_bind = read_accessor(gltf, skin.inverseBindMatrices)
+    inverse_bind = inverse_bind.reshape((-1, 4, 4)).transpose(0, 2, 1)
+    globals_ = node_global_matrices(gltf, local_joint_deltas)
+    joint_mats = np.stack([globals_[joint] @ inverse_bind[index] for index, joint in enumerate(skin.joints)])
+
+    deformed: list[np.ndarray] = []
+    for mesh in gltf.meshes or []:
+        for primitive in mesh.primitives:
+            positions = read_accessor(gltf, primitive.attributes.POSITION).astype(np.float64)
+            joints_accessor = getattr(primitive.attributes, "JOINTS_0", None)
+            weights_accessor = getattr(primitive.attributes, "WEIGHTS_0", None)
+            if joints_accessor is None or weights_accessor is None:
+                deformed.append(positions)
+                continue
+
+            joints = read_accessor(gltf, joints_accessor).astype(np.int64)
+            weights = read_accessor(gltf, weights_accessor).astype(np.float64)
+            weights = weights / (weights.sum(axis=1, keepdims=True) + 1e-12)
+            homogeneous = np.c_[positions, np.ones(len(positions), dtype=np.float64)]
+            out = np.zeros((len(positions), 4), dtype=np.float64)
+            for weight_index in range(weights.shape[1]):
+                out += weights[:, weight_index : weight_index + 1] * np.einsum(
+                    "nij,nj->ni", joint_mats[joints[:, weight_index]], homogeneous
+                )
+            deformed.append(out[:, :3])
+    return deformed
+
+
+def identity_quaternions(count: int) -> np.ndarray:
+    quats = np.zeros((count, 4), dtype=np.float64)
+    quats[:, 3] = 1.0
+    return quats
+
+
+@dataclass(frozen=True)
+class VertexNormalizer:
+    scale: float
+    source_ground: float
+    target_ground_y: float
+    source_up_axis: int = 2
+
+    @property
+    def _axis_order(self) -> tuple[int, int, int]:
+        if self.source_up_axis == 2:
+            return (0, 2, 1)
+        if self.source_up_axis == 1:
+            return (0, 1, 2)
+        return (1, 0, 2)
+
+    @classmethod
+    def from_vertices(
+        cls,
+        vertices_by_primitive: list[np.ndarray],
+        *,
+        target_height: float,
+        ground_y: float,
+        source_up_axis: int = 2,
+    ) -> "VertexNormalizer":
+        combined = np.vstack(vertices_by_primitive)
+        source_ground = float(combined[:, source_up_axis].min())
+        source_top = float(combined[:, source_up_axis].max())
+        height = max(source_top - source_ground, 1e-9)
+        return cls(
+            scale=float(target_height) / height,
+            source_ground=source_ground,
+            target_ground_y=ground_y,
+            source_up_axis=source_up_axis,
+        )
+
+    def _to_target_axes(self, values: np.ndarray) -> np.ndarray:
+        out = values[:, self._axis_order].copy()
+        out[:, 1] -= self.source_ground
+        out *= self.scale
+        out[:, 1] += self.target_ground_y
+        return out
+
+    def transform(
+        self,
+        vertices_by_primitive: list[np.ndarray],
+        points: np.ndarray | None = None,
+        *,
+        root_offset: np.ndarray | None = None,
+        snap_to_ground: bool = True,
+    ) -> tuple[list[np.ndarray], np.ndarray | None]:
+        transformed = [self._to_target_axes(vertices) for vertices in vertices_by_primitive]
+
+        transformed_points = None
+        if points is not None:
+            transformed_points = self._to_target_axes(points)
+
+        if root_offset is not None:
+            root = np.asarray(root_offset, dtype=np.float64)
+            transformed = [vertices + root for vertices in transformed]
+            if transformed_points is not None:
+                transformed_points = transformed_points + root
+
+        if snap_to_ground:
+            lowest = min(float(vertices[:, 1].min()) for vertices in transformed)
+            if lowest < self.target_ground_y:
+                lift = self.target_ground_y - lowest
+                transformed = [vertices + np.array([0.0, lift, 0.0]) for vertices in transformed]
+                if transformed_points is not None:
+                    transformed_points = transformed_points + np.array([0.0, lift, 0.0])
+
+        return transformed, transformed_points
+
+
+def write_object_config(path: Path, glb_path: Path) -> None:
+    config = {
+        "render_asset": glb_path.name,
+        "collision_asset": glb_path.name,
+        "scale": [1.0, 1.0, 1.0],
+        "use_mesh_for_collision": True,
+        "requires_lighting": True,
+        "mass": 1.0,
+        "margin": 0.0,
+    }
+    path.write_text(json.dumps(config, indent=2), encoding="utf-8")

--- a/src/havln3/materials.py
+++ b/src/havln3/materials.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from pygltflib import GLTF2
+
+
+_ALPHA_KEYWORDS = ("hair", "lash", "eyelash", "brow")
+
+
+def _image_bytes(gltf: GLTF2, image_index: int, glb_path: Path) -> bytes | None:
+    image = gltf.images[image_index]
+    if image.bufferView is not None:
+        view = gltf.bufferViews[image.bufferView]
+        blob = gltf.binary_blob()
+        start = int(view.byteOffset or 0)
+        end = start + int(view.byteLength or 0)
+        return bytes(blob[start:end])
+    if image.uri:
+        if image.uri.startswith("data:"):
+            _, encoded = image.uri.split(",", 1)
+            return base64.b64decode(encoded)
+        image_path = (glb_path.parent / image.uri).resolve()
+        if image_path.exists():
+            return image_path.read_bytes()
+    return None
+
+
+def _base_color_has_alpha(gltf: GLTF2, material: Any, glb_path: Path) -> bool:
+    pbr = material.pbrMetallicRoughness
+    if not pbr or not pbr.baseColorTexture:
+        return False
+    texture = gltf.textures[pbr.baseColorTexture.index]
+    if texture.source is None:
+        return False
+    raw = _image_bytes(gltf, texture.source, glb_path)
+    if not raw:
+        return False
+    try:
+        with Image.open(io.BytesIO(raw)) as image:
+            if image.mode not in {"RGBA", "LA"} and "transparency" not in image.info:
+                return False
+            alpha = np.asarray(image.convert("RGBA"))[:, :, 3]
+            return float((alpha < 250).mean()) > 0.01
+    except Exception:
+        return False
+
+
+def fix_habitat_materials(
+    glb_path: Path,
+    *,
+    alpha_cutoff: float = 0.55,
+    roughness: float = 0.88,
+    detect_texture_alpha: bool = True,
+) -> list[dict[str, object]]:
+    """Make exported avatar frames friendlier to Habitat/ViCo rendering.
+
+    The fix preserves original UVs and base-color textures. It changes only
+    render-state metadata that commonly causes transparent hair cards to sort
+    badly in Habitat. Exported animation frames are always marked double-sided
+    because Habitat side/back camera views can otherwise make single-surface
+    clothing read as a flat paper cutout.
+    """
+
+    gltf = GLTF2().load(str(glb_path))
+    changes: list[dict[str, object]] = []
+    for index, material in enumerate(gltf.materials or []):
+        name = material.name or f"material_{index}"
+        lower = name.lower()
+        pbr = material.pbrMetallicRoughness
+        before = {
+            "name": name,
+            "alphaMode": material.alphaMode,
+            "alphaCutoff": material.alphaCutoff,
+            "doubleSided": material.doubleSided,
+            "metallicFactor": pbr.metallicFactor if pbr else None,
+            "roughnessFactor": pbr.roughnessFactor if pbr else None,
+        }
+
+        if pbr is not None:
+            pbr.metallicFactor = 0.0
+            pbr.roughnessFactor = max(float(pbr.roughnessFactor or 0.0), roughness)
+            pbr.metallicRoughnessTexture = None
+
+        alpha_like = any(keyword in lower for keyword in _ALPHA_KEYWORDS)
+        if detect_texture_alpha and not alpha_like:
+            alpha_like = material.alphaMode == "BLEND" or _base_color_has_alpha(gltf, material, glb_path)
+        if alpha_like:
+            material.alphaMode = "MASK"
+            material.alphaCutoff = alpha_cutoff
+        else:
+            material.alphaMode = "OPAQUE"
+            material.alphaCutoff = None
+            if pbr is not None and pbr.baseColorFactor and len(pbr.baseColorFactor) >= 4:
+                pbr.baseColorFactor[3] = 1.0
+        material.doubleSided = True
+
+        after = {
+            "name": name,
+            "alphaMode": material.alphaMode,
+            "alphaCutoff": material.alphaCutoff,
+            "doubleSided": material.doubleSided,
+            "metallicFactor": pbr.metallicFactor if pbr else None,
+            "roughnessFactor": pbr.roughnessFactor if pbr else None,
+        }
+        if after != before:
+            changes.append({"material_index": index, "before": before, "after": after})
+
+    if changes:
+        gltf.save_binary(str(glb_path))
+    return changes

--- a/src/havln3/motion.py
+++ b/src/havln3/motion.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from scipy.spatial.transform import Rotation, Slerp
+
+
+SMPL22_JOINT_NAMES = (
+    "Hips",
+    "LeftUpLeg",
+    "RightUpLeg",
+    "Spine",
+    "LeftLeg",
+    "RightLeg",
+    "Spine1",
+    "LeftFoot",
+    "RightFoot",
+    "Spine2",
+    "LeftToeBase",
+    "RightToeBase",
+    "Neck",
+    "LeftShoulder",
+    "RightShoulder",
+    "Head",
+    "LeftArm",
+    "RightArm",
+    "LeftForeArm",
+    "RightForeArm",
+    "LeftHand",
+    "RightHand",
+)
+
+SMPL22_TO_MIXAMO = {index: name for index, name in enumerate(SMPL22_JOINT_NAMES)}
+
+
+@dataclass(frozen=True)
+class MotionClip:
+    local_rot_mats: np.ndarray
+    root_positions: np.ndarray | None
+    posed_joints: np.ndarray | None
+    foot_contacts: np.ndarray | None
+    source_path: Path
+    prompt: str | None = None
+    fps: float | None = None
+    global_rot_mats: np.ndarray | None = None
+
+    @property
+    def frames(self) -> int:
+        return int(self.local_rot_mats.shape[0])
+
+
+def _rotvecs_to_mats(root_orient: np.ndarray, pose_body: np.ndarray) -> np.ndarray:
+    frames = int(root_orient.shape[0])
+    mats = np.tile(np.eye(3, dtype=np.float64), (frames, 22, 1, 1))
+    mats[:, 0] = Rotation.from_rotvec(root_orient.reshape(frames, 3)).as_matrix()
+    body = pose_body.reshape(frames, 21, 3)
+    mats[:, 1:22] = Rotation.from_rotvec(body.reshape(-1, 3)).as_matrix().reshape(frames, 21, 3, 3)
+    return mats
+
+
+def _load_torch_smpl_params(path: Path, param_group: str = "body_params_global") -> MotionClip:
+    import torch
+
+    params = torch.load(path, map_location="cpu")
+    source = params[param_group]
+    body_pose = source["body_pose"].detach().float().cpu().numpy()
+    global_orient = source["global_orient"].detach().float().cpu().numpy()
+    root_positions = None
+    for key in ("transl", "trans", "translation"):
+        if key in source:
+            root_positions = source[key].detach().float().cpu().numpy()
+            break
+    prompt = None
+    segment_info = params.get("segment_info")
+    if isinstance(segment_info, list) and segment_info:
+        prompt = segment_info[0].get("caption")
+    mats = _rotvecs_to_mats(global_orient, body_pose)
+    return MotionClip(
+        local_rot_mats=mats,
+        root_positions=root_positions,
+        posed_joints=None,
+        foot_contacts=None,
+        source_path=path,
+        prompt=prompt,
+    )
+
+
+def load_motion_file(
+    motion_path: Path,
+    *,
+    amass_path: Path | None = None,
+    gem_param_group: str = "body_params_global",
+) -> MotionClip:
+    if motion_path.suffix == ".pt":
+        return _load_torch_smpl_params(motion_path, gem_param_group)
+
+    data = np.load(motion_path, allow_pickle=True)
+    if "local_rot_mats" in data:
+        fps = float(data["fps"]) if "fps" in data else None
+        root = data["smooth_root_pos"] if "smooth_root_pos" in data else data.get("root_positions")
+        return MotionClip(
+            local_rot_mats=data["local_rot_mats"].astype(np.float64),
+            root_positions=None if root is None else root.astype(np.float64),
+            posed_joints=data["posed_joints"].astype(np.float64) if "posed_joints" in data else None,
+            foot_contacts=data["foot_contacts"].astype(bool) if "foot_contacts" in data else None,
+            source_path=motion_path,
+            fps=fps,
+            global_rot_mats=data["global_rot_mats"].astype(np.float64) if "global_rot_mats" in data else None,
+        )
+
+    if "root_orient" in data and "pose_body" in data:
+        return MotionClip(
+            local_rot_mats=_rotvecs_to_mats(data["root_orient"], data["pose_body"]),
+            root_positions=data["trans"].astype(np.float64) if "trans" in data else None,
+            posed_joints=None,
+            foot_contacts=data["foot_contacts"].astype(bool) if "foot_contacts" in data else None,
+            source_path=motion_path,
+            fps=float(data["mocap_frame_rate"]) if "mocap_frame_rate" in data else None,
+            global_rot_mats=None,
+        )
+
+    if amass_path:
+        return load_motion_file(amass_path, gem_param_group=gem_param_group)
+    raise ValueError(f"unsupported motion file format: {motion_path}")
+
+
+def _resample_array(values: np.ndarray | None, target_frames: int) -> np.ndarray | None:
+    if values is None or len(values) == target_frames:
+        return values
+    src_t = np.linspace(0.0, 1.0, len(values))
+    dst_t = np.linspace(0.0, 1.0, target_frames)
+    flat = values.reshape(len(values), -1)
+    out = np.empty((target_frames, flat.shape[1]), dtype=np.float64)
+    for channel in range(flat.shape[1]):
+        out[:, channel] = np.interp(dst_t, src_t, flat[:, channel])
+    return out.reshape((target_frames,) + values.shape[1:])
+
+
+def _resample_rotations(mats: np.ndarray, target_frames: int) -> np.ndarray:
+    if len(mats) == target_frames:
+        return mats
+    src_t = np.linspace(0.0, 1.0, len(mats))
+    dst_t = np.linspace(0.0, 1.0, target_frames)
+    out = np.empty((target_frames,) + mats.shape[1:], dtype=np.float64)
+    for joint_index in range(mats.shape[1]):
+        rotations = Rotation.from_matrix(mats[:, joint_index])
+        out[:, joint_index] = Slerp(src_t, rotations)(dst_t).as_matrix()
+    return out
+
+
+def _resample_contacts(values: np.ndarray | None, target_frames: int) -> np.ndarray | None:
+    if values is None or len(values) == target_frames:
+        return values
+    indices = np.rint(np.linspace(0, len(values) - 1, target_frames)).astype(np.int64)
+    return values[indices].astype(bool)
+
+
+def resample_motion(clip: MotionClip, target_frames: int) -> MotionClip:
+    return MotionClip(
+        local_rot_mats=_resample_rotations(clip.local_rot_mats, target_frames),
+        root_positions=_resample_array(clip.root_positions, target_frames),
+        posed_joints=_resample_array(clip.posed_joints, target_frames),
+        foot_contacts=_resample_contacts(clip.foot_contacts, target_frames),
+        source_path=clip.source_path,
+        prompt=clip.prompt,
+        fps=clip.fps,
+        global_rot_mats=_resample_rotations(clip.global_rot_mats, target_frames)
+        if clip.global_rot_mats is not None
+        else None,
+    )
+
+
+def generate_kimodo_motion(
+    prompt: str,
+    output_stem: Path,
+    *,
+    model: str = "Kimodo-SMPLX-RP-v1",
+    duration: float = 5.0,
+    kimodo_bin: str = "kimodo_gen",
+    seed: int | None = None,
+    cfg_type: str | None = None,
+    extra_args: list[str] | None = None,
+    num_samples: int = 1,
+) -> tuple[Path, Path | None]:
+    candidates = generate_kimodo_motion_candidates(
+        prompt,
+        output_stem,
+        model=model,
+        duration=duration,
+        kimodo_bin=kimodo_bin,
+        seed=seed,
+        cfg_type=cfg_type,
+        extra_args=extra_args,
+        num_samples=num_samples,
+    )
+    if candidates:
+        return candidates[0]
+    motion_path = output_stem.with_suffix(".npz")
+    amass_path = output_stem.with_name(output_stem.name + "_amass.npz")
+    return motion_path, amass_path if amass_path.exists() else None
+
+
+def generate_kimodo_motion_candidates(
+    prompt: str,
+    output_stem: Path,
+    *,
+    model: str = "Kimodo-SMPLX-RP-v1",
+    duration: float = 5.0,
+    kimodo_bin: str = "kimodo_gen",
+    seed: int | None = None,
+    cfg_type: str | None = None,
+    extra_args: list[str] | None = None,
+    num_samples: int = 1,
+) -> list[tuple[Path, Path | None]]:
+    executable = shutil.which(kimodo_bin)
+    if not executable:
+        raise RuntimeError(
+            f"{kimodo_bin!r} was not found. Install Kimodo or pass --motion-npz to retarget an existing output."
+        )
+    output_stem.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        executable,
+        prompt,
+        "--model",
+        model,
+        "--duration",
+        str(duration),
+        "--output",
+        str(output_stem),
+        "--num_samples",
+        str(max(1, num_samples)),
+    ]
+    if seed is not None:
+        command.extend(["--seed", str(seed)])
+    if cfg_type:
+        command.extend(["--cfg_type", cfg_type])
+    if extra_args:
+        command.extend(extra_args)
+    subprocess.run(command, check=True)
+
+    return _generated_motion_candidates(output_stem)
+
+
+def _generated_motion_candidates(output_stem: Path) -> list[tuple[Path, Path | None]]:
+    candidates: list[Path] = []
+
+    def append_unique(paths: list[Path]) -> None:
+        for path in paths:
+            if path.exists() and path not in candidates:
+                candidates.append(path)
+
+    direct = output_stem.with_suffix(".npz")
+    append_unique([direct])
+    append_unique(sorted(output_stem.parent.glob(f"{output_stem.name}*.npz")))
+    append_unique(sorted((output_stem.parent / output_stem.name).glob(f"{output_stem.name}*.npz")))
+    if output_stem.is_dir():
+        append_unique(sorted(output_stem.glob(f"{output_stem.name}*.npz")))
+    if not candidates:
+        return []
+
+    result: list[tuple[Path, Path | None]] = []
+    for motion_path in candidates:
+        suffix = motion_path.stem.removeprefix(output_stem.name).lstrip("_")
+        companion_names = [
+            motion_path.with_name(motion_path.stem + "_amass.npz"),
+            motion_path.parent / f"amass_{suffix}.npz" if suffix else None,
+            output_stem.with_name(output_stem.name + "_amass.npz"),
+        ]
+        if suffix:
+            companion_names.append(output_stem.with_name(f"amass_{suffix}.npz"))
+            companion_names.append(output_stem / f"amass_{suffix}.npz")
+        companion_names.append(output_stem / f"{output_stem.name}_amass.npz")
+        amass_path = next((path for path in companion_names if path and path.exists()), None)
+        result.append((motion_path, amass_path))
+    return result

--- a/src/havln3/motion_quality.py
+++ b/src/havln3/motion_quality.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from havln3.motion import MotionClip, load_motion_file, resample_motion
+
+
+SMPL_LEG_JOINTS = {
+    "Left": {"hip": 1, "knee": 4, "ankle": 7, "toe": 10},
+    "Right": {"hip": 2, "knee": 5, "ankle": 8, "toe": 11},
+}
+
+
+@dataclass(frozen=True)
+class MotionQualityOptions:
+    frames: int = 60
+    min_score: float = 62.0
+    min_backflip_rotation_degrees: float = 280.0
+    min_backflip_total_degrees: float = 240.0
+    max_leg_direction_acceleration: float = 0.52
+    max_leg_direction_velocity: float = 1.65
+    min_leg_reach_ratio: float = 0.22
+    min_knee_angle_degrees: float = 22.0
+    min_foot_head_distance_ratio: float = 0.11
+    min_limb_core_clearance_ratio: float = 0.075
+    min_hand_foot_clearance_ratio: float = 0.08
+    min_knee_chest_clearance_ratio: float = 0.10
+    max_root_drift_ratio: float = 1.15
+
+
+@dataclass(frozen=True)
+class MotionQualityReport:
+    path: str
+    score: float
+    passed: bool
+    reasons: list[str]
+    metrics: dict[str, float | int | bool | str | None]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "score": self.score,
+            "passed": self.passed,
+            "reasons": self.reasons,
+            "metrics": self.metrics,
+        }
+
+
+def _source_to_quality_axes(points: np.ndarray) -> np.ndarray:
+    return points
+
+
+def _safe_unit(vector: np.ndarray) -> np.ndarray | None:
+    norm = float(np.linalg.norm(vector))
+    if norm < 1e-8:
+        return None
+    return vector / norm
+
+
+def _projected_unit(vector: np.ndarray, normal: np.ndarray) -> np.ndarray | None:
+    projected = vector - normal * float(np.dot(vector, normal))
+    return _safe_unit(projected)
+
+
+def _orthonormal_body_basis(points: np.ndarray) -> np.ndarray | None:
+    if len(points) <= 3:
+        return None
+    hips = points[0]
+    side = _safe_unit(points[SMPL_LEG_JOINTS["Right"]["hip"]] - points[SMPL_LEG_JOINTS["Left"]["hip"]])
+    if side is None:
+        return None
+    for spine_index in (9, 6, 3, 15):
+        if spine_index >= len(points):
+            continue
+        up = _projected_unit(points[spine_index] - hips, side)
+        if up is None:
+            continue
+        forward = _safe_unit(np.cross(side, up))
+        if forward is None:
+            continue
+        up = _safe_unit(np.cross(forward, side))
+        if up is None:
+            continue
+        return np.column_stack([side, up, forward])
+    return None
+
+
+def _angle_degrees(a: np.ndarray, b: np.ndarray) -> float | None:
+    a_unit = _safe_unit(a)
+    b_unit = _safe_unit(b)
+    if a_unit is None or b_unit is None:
+        return None
+    return float(np.degrees(np.arccos(np.clip(float(np.dot(a_unit, b_unit)), -1.0, 1.0))))
+
+
+def _is_backflip_prompt(prompt: str | None) -> bool:
+    text = (prompt or "").lower()
+    return "backflip" in text or "back flip" in text or "后空翻" in text
+
+
+def _is_stationary_prompt(prompt: str | None) -> bool:
+    text = (prompt or "").lower()
+    return any(token in text for token in ("standing", "stationary", "in place", "原地"))
+
+
+def _finite_or_default(value: float | None, default: float = 0.0) -> float:
+    if value is None or not np.isfinite(value):
+        return default
+    return float(value)
+
+
+def _penalize_above(value: float, limit: float, scale: float) -> float:
+    return max(0.0, value - limit) * scale
+
+
+def _penalize_below(value: float, limit: float, scale: float) -> float:
+    return max(0.0, limit - value) * scale
+
+
+def _motion_points(clip: MotionClip, frames: int) -> np.ndarray | None:
+    if clip.posed_joints is None:
+        return None
+    sampled = resample_motion(clip, frames)
+    if sampled.posed_joints is None:
+        return None
+    return np.asarray([_source_to_quality_axes(frame) for frame in sampled.posed_joints], dtype=np.float64)
+
+
+def _body_height(points: np.ndarray) -> float:
+    extents = np.nanmax(points, axis=1) - np.nanmin(points, axis=1)
+    heights = np.linalg.norm(extents, axis=1)
+    return max(float(np.nanmedian(heights)), 1e-6)
+
+
+def _backflip_metrics(points: np.ndarray) -> dict[str, float]:
+    first_basis = _orthonormal_body_basis(points[0])
+    if first_basis is None:
+        return {
+            "backflip_rotation_span_degrees": 0.0,
+            "backflip_total_degrees": 0.0,
+            "backflip_direction_consistency": 0.0,
+            "upside_down_dot": 1.0,
+            "final_upright_dot": 0.0,
+        }
+    up0 = first_basis[:, 1]
+    forward0 = first_basis[:, 2]
+    angles: list[float] = []
+    up_dots: list[float] = []
+    for frame in points:
+        up = _safe_unit(frame[15] - frame[0])
+        if up is None:
+            continue
+        up_dots.append(float(np.dot(up, up0)))
+        angles.append(float(np.arctan2(np.dot(up, forward0), np.dot(up, up0))))
+    if len(angles) < 2:
+        return {
+            "backflip_rotation_span_degrees": 0.0,
+            "backflip_total_degrees": 0.0,
+            "backflip_direction_consistency": 0.0,
+            "upside_down_dot": 1.0,
+            "final_upright_dot": 0.0,
+        }
+    unwrapped = np.unwrap(np.asarray(angles, dtype=np.float64))
+    total = float(np.degrees(unwrapped[-1] - unwrapped[0]))
+    span = float(np.degrees(np.nanmax(unwrapped) - np.nanmin(unwrapped)))
+    direction = np.sign(total) if abs(total) > 1e-6 else 1.0
+    deltas = np.diff(unwrapped) * direction
+    consistency = float(np.mean(deltas > -0.08)) if len(deltas) else 0.0
+    return {
+        "backflip_rotation_span_degrees": span,
+        "backflip_total_degrees": abs(total),
+        "backflip_direction_consistency": consistency,
+        "upside_down_dot": float(np.nanmin(up_dots)) if up_dots else 1.0,
+        "final_upright_dot": float(up_dots[-1]) if up_dots else 0.0,
+    }
+
+
+def _leg_metrics(points: np.ndarray, body_height: float) -> dict[str, float]:
+    frame_count = len(points)
+    local_dirs = np.full((frame_count, 2, 3), np.nan, dtype=np.float64)
+    reach_ratios = np.full((frame_count, 2), np.nan, dtype=np.float64)
+    knee_angles: list[float] = []
+    foot_head_distances: list[float] = []
+    asymmetry: list[float] = []
+
+    for frame_index, frame in enumerate(points):
+        basis = _orthonormal_body_basis(frame)
+        if basis is None:
+            continue
+        mirrored_dirs: list[np.ndarray] = []
+        for side_index, side in enumerate(("Left", "Right")):
+            joints = SMPL_LEG_JOINTS[side]
+            hip = frame[joints["hip"]]
+            knee = frame[joints["knee"]]
+            ankle = frame[joints["ankle"]]
+            toe = frame[joints["toe"]]
+            direction = _safe_unit(ankle - hip)
+            upper_len = float(np.linalg.norm(knee - hip))
+            lower_len = float(np.linalg.norm(ankle - knee))
+            chain_len = upper_len + lower_len
+            if direction is not None:
+                local_direction = _safe_unit(basis.T @ direction)
+                if local_direction is not None:
+                    local_dirs[frame_index, side_index] = local_direction
+                    mirrored = local_direction.copy()
+                    if side == "Right":
+                        mirrored[0] *= -1.0
+                    mirrored_dirs.append(mirrored)
+            if chain_len > 1e-8:
+                reach_ratios[frame_index, side_index] = float(np.linalg.norm(ankle - hip) / chain_len)
+            knee_angle = _angle_degrees(hip - knee, ankle - knee)
+            if knee_angle is not None:
+                knee_angles.append(knee_angle)
+            head = frame[15]
+            foot_head_distances.extend(
+                [
+                    float(np.linalg.norm(ankle - head) / body_height),
+                    float(np.linalg.norm(toe - head) / body_height),
+                ]
+            )
+        if len(mirrored_dirs) == 2:
+            asymmetry.append(float(np.linalg.norm(mirrored_dirs[0] - mirrored_dirs[1])))
+
+    valid_dirs = np.nan_to_num(local_dirs, nan=0.0)
+    direction_velocity = np.diff(valid_dirs, axis=0).reshape(max(frame_count - 1, 0), -1)
+    direction_acceleration = np.diff(valid_dirs, n=2, axis=0).reshape(max(frame_count - 2, 0), -1)
+    return {
+        "leg_direction_velocity_max": float(np.nanmax(np.linalg.norm(direction_velocity, axis=1)))
+        if len(direction_velocity)
+        else 0.0,
+        "leg_direction_acceleration_mean": float(np.nanmean(np.linalg.norm(direction_acceleration, axis=1)))
+        if len(direction_acceleration)
+        else 0.0,
+        "leg_reach_ratio_min": float(np.nanmin(reach_ratios)) if not np.isnan(reach_ratios).all() else 0.0,
+        "knee_angle_min_degrees": float(np.nanmin(knee_angles)) if knee_angles else 0.0,
+        "foot_head_distance_min_ratio": float(np.nanmin(foot_head_distances)) if foot_head_distances else 0.0,
+        "leg_asymmetry_mean": float(np.nanmean(asymmetry)) if asymmetry else 0.0,
+    }
+
+
+def _min_pair_distance_ratio(
+    frame: np.ndarray,
+    left_indices: tuple[int, ...],
+    right_indices: tuple[int, ...],
+    body_height: float,
+) -> float:
+    distances: list[float] = []
+    for left_index in left_indices:
+        if left_index >= len(frame):
+            continue
+        for right_index in right_indices:
+            if right_index >= len(frame):
+                continue
+            distances.append(float(np.linalg.norm(frame[left_index] - frame[right_index]) / body_height))
+    return float(np.nanmin(distances)) if distances else float("inf")
+
+
+def _self_contact_metrics(points: np.ndarray, body_height: float) -> dict[str, float]:
+    # SMPL-22 joints: feet/toes/wrists should not pass through the torso/head in
+    # tight tuck phases. These skeleton-space clearances catch samples that look
+    # numerically valid but tend to produce mesh self-intersection after retarget.
+    limb_indices = (7, 8, 10, 11, 18, 19, 20, 21)
+    core_indices = (3, 6, 9, 12, 15)
+    hand_indices = (20, 21)
+    foot_indices = (7, 8, 10, 11)
+    knee_indices = (4, 5)
+    chest_indices = (6, 9, 12)
+
+    limb_core: list[float] = []
+    hand_foot: list[float] = []
+    knee_chest: list[float] = []
+    for frame in points:
+        limb_core.append(_min_pair_distance_ratio(frame, limb_indices, core_indices, body_height))
+        hand_foot.append(_min_pair_distance_ratio(frame, hand_indices, foot_indices, body_height))
+        knee_chest.append(_min_pair_distance_ratio(frame, knee_indices, chest_indices, body_height))
+
+    return {
+        "limb_core_clearance_min_ratio": float(np.nanmin(limb_core)) if limb_core else 0.0,
+        "hand_foot_clearance_min_ratio": float(np.nanmin(hand_foot)) if hand_foot else 0.0,
+        "knee_chest_clearance_min_ratio": float(np.nanmin(knee_chest)) if knee_chest else 0.0,
+    }
+
+
+def _shape_jerk(points: np.ndarray, body_height: float) -> float:
+    local = points - points[:, :1]
+    acceleration = np.diff(local, n=2, axis=0)
+    if len(acceleration) == 0:
+        return 0.0
+    return float(np.nanmean(np.linalg.norm(acceleration.reshape(len(acceleration), -1), axis=1)) / body_height)
+
+
+def _root_drift_ratio(clip: MotionClip, frames: int, body_height: float) -> float:
+    if clip.root_positions is None:
+        return 0.0
+    root = resample_motion(clip, frames).root_positions
+    if root is None or len(root) < 2:
+        return 0.0
+    horizontal = root[:, [0, 2]]
+    drift = float(np.linalg.norm(horizontal[-1] - horizontal[0]))
+    return drift / body_height
+
+
+def score_motion_clip(
+    clip: MotionClip,
+    *,
+    prompt: str | None = None,
+    options: MotionQualityOptions | None = None,
+) -> MotionQualityReport:
+    options = options or MotionQualityOptions()
+    points = _motion_points(clip, options.frames)
+    reasons: list[str] = []
+    if points is None:
+        return MotionQualityReport(
+            path=str(clip.source_path),
+            score=0.0,
+            passed=False,
+            reasons=["missing posed_joints; cannot evaluate Kimodo skeleton quality"],
+            metrics={"has_posed_joints": False},
+        )
+    finite_ratio = float(np.isfinite(points).mean())
+    body_height = _body_height(points)
+    metrics: dict[str, float | int | bool | str | None] = {
+        "has_posed_joints": True,
+        "finite_ratio": finite_ratio,
+        "body_height": body_height,
+        "frames": int(options.frames),
+    }
+    metrics.update(_backflip_metrics(points))
+    metrics.update(_leg_metrics(points, body_height))
+    metrics.update(_self_contact_metrics(points, body_height))
+    metrics["shape_jerk"] = _shape_jerk(points, body_height)
+    metrics["root_drift_ratio"] = _root_drift_ratio(clip, options.frames, body_height)
+
+    score = 100.0
+    if finite_ratio < 0.999:
+        score -= (0.999 - finite_ratio) * 250.0
+        reasons.append("non-finite joint values")
+
+    score -= _penalize_above(
+        float(metrics["shape_jerk"]),
+        0.12,
+        65.0,
+    )
+    score -= _penalize_above(
+        float(metrics["leg_direction_acceleration_mean"]),
+        options.max_leg_direction_acceleration,
+        26.0,
+    )
+    score -= _penalize_above(
+        float(metrics["leg_direction_velocity_max"]),
+        options.max_leg_direction_velocity,
+        16.0,
+    )
+    score -= _penalize_below(
+        float(metrics["leg_reach_ratio_min"]),
+        options.min_leg_reach_ratio,
+        80.0,
+    )
+    score -= _penalize_below(
+        float(metrics["knee_angle_min_degrees"]),
+        options.min_knee_angle_degrees,
+        0.85,
+    )
+    score -= _penalize_below(
+        float(metrics["foot_head_distance_min_ratio"]),
+        options.min_foot_head_distance_ratio,
+        115.0,
+    )
+    score -= _penalize_below(
+        float(metrics["limb_core_clearance_min_ratio"]),
+        options.min_limb_core_clearance_ratio,
+        120.0,
+    )
+    score -= _penalize_below(
+        float(metrics["hand_foot_clearance_min_ratio"]),
+        options.min_hand_foot_clearance_ratio,
+        90.0,
+    )
+    score -= _penalize_below(
+        float(metrics["knee_chest_clearance_min_ratio"]),
+        options.min_knee_chest_clearance_ratio,
+        90.0,
+    )
+    score -= _penalize_above(float(metrics["leg_asymmetry_mean"]), 0.62, 14.0)
+
+    if _is_backflip_prompt(prompt or clip.prompt):
+        span = float(metrics["backflip_rotation_span_degrees"])
+        total = float(metrics["backflip_total_degrees"])
+        consistency = float(metrics["backflip_direction_consistency"])
+        upside_down_dot = float(metrics["upside_down_dot"])
+        final_upright_dot = float(metrics["final_upright_dot"])
+        if span < options.min_backflip_rotation_degrees:
+            score -= (options.min_backflip_rotation_degrees - span) * 0.18
+            reasons.append("backflip rotation span is too small")
+        if total < options.min_backflip_total_degrees:
+            score -= (options.min_backflip_total_degrees - total) * 0.14
+            reasons.append("backflip does not complete enough net rotation")
+        if consistency < 0.58:
+            score -= (0.58 - consistency) * 28.0
+            reasons.append("backflip direction is inconsistent")
+        if upside_down_dot > -0.35:
+            score -= (upside_down_dot + 0.35) * 24.0
+            reasons.append("motion never reaches a clear inverted torso phase")
+        if final_upright_dot < 0.45:
+            score -= (0.45 - final_upright_dot) * 20.0
+            reasons.append("motion does not return near upright")
+
+    if _is_stationary_prompt(prompt or clip.prompt):
+        drift = float(metrics["root_drift_ratio"])
+        if drift > options.max_root_drift_ratio:
+            score -= (drift - options.max_root_drift_ratio) * 18.0
+            reasons.append("root drifts too far for a stationary prompt")
+
+    if float(metrics["leg_reach_ratio_min"]) < options.min_leg_reach_ratio:
+        reasons.append("leg chain collapses too tightly")
+    if float(metrics["foot_head_distance_min_ratio"]) < options.min_foot_head_distance_ratio:
+        reasons.append("foot gets too close to head/face")
+    if float(metrics["limb_core_clearance_min_ratio"]) < options.min_limb_core_clearance_ratio:
+        reasons.append("limbs get too close to torso/head")
+    if float(metrics["hand_foot_clearance_min_ratio"]) < options.min_hand_foot_clearance_ratio:
+        reasons.append("hands and feet get too close during tuck")
+    if float(metrics["knee_chest_clearance_min_ratio"]) < options.min_knee_chest_clearance_ratio:
+        reasons.append("knees tuck too tightly into chest")
+    if float(metrics["knee_angle_min_degrees"]) < options.min_knee_angle_degrees:
+        reasons.append("knee fold angle is too extreme")
+    if float(metrics["leg_direction_acceleration_mean"]) > options.max_leg_direction_acceleration:
+        reasons.append("airborne leg direction changes too abruptly")
+
+    score = float(np.clip(score, 0.0, 100.0))
+    passed = score >= options.min_score and not any(
+        reason
+        in {
+            "missing posed_joints; cannot evaluate Kimodo skeleton quality",
+            "non-finite joint values",
+        }
+        for reason in reasons
+    )
+    return MotionQualityReport(
+        path=str(clip.source_path),
+        score=score,
+        passed=passed,
+        reasons=reasons,
+        metrics={key: _finite_or_default(value) if isinstance(value, float) else value for key, value in metrics.items()},
+    )
+
+
+def score_motion_file(
+    path: Path,
+    *,
+    prompt: str | None = None,
+    options: MotionQualityOptions | None = None,
+    gem_param_group: str = "body_params_global",
+) -> MotionQualityReport:
+    clip = load_motion_file(path, gem_param_group=gem_param_group)
+    return score_motion_clip(clip, prompt=prompt, options=options)
+
+
+def rank_motion_files(
+    paths: list[Path],
+    *,
+    prompt: str | None = None,
+    options: MotionQualityOptions | None = None,
+    gem_param_group: str = "body_params_global",
+) -> list[MotionQualityReport]:
+    reports = [
+        score_motion_file(
+            path,
+            prompt=prompt,
+            options=options,
+            gem_param_group=gem_param_group,
+        )
+        for path in paths
+    ]
+    return sorted(reports, key=lambda report: report.score, reverse=True)
+
+
+def write_motion_quality_report(path: Path, reports: list[MotionQualityReport]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "selected": reports[0].to_dict() if reports else None,
+                "candidates": [report.to_dict() for report in reports],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )

--- a/src/havln3/motion_quality.py
+++ b/src/havln3/motion_quality.py
@@ -15,6 +15,11 @@ SMPL_LEG_JOINTS = {
     "Right": {"hip": 2, "knee": 5, "ankle": 8, "toe": 11},
 }
 
+SMPL_ARM_JOINTS = {
+    "Left": {"shoulder": 16, "elbow": 18, "hand": 20},
+    "Right": {"shoulder": 17, "elbow": 19, "hand": 21},
+}
+
 
 @dataclass(frozen=True)
 class MotionQualityOptions:
@@ -31,6 +36,15 @@ class MotionQualityOptions:
     min_hand_foot_clearance_ratio: float = 0.08
     min_knee_chest_clearance_ratio: float = 0.10
     max_root_drift_ratio: float = 1.15
+    min_running_arm_forward_range_ratio: float = 0.07
+    max_running_hand_lateral_p95_ratio: float = 0.34
+    min_running_arm_leg_counterphase: float = 0.08
+    min_running_hand_opposition: float = 0.06
+    min_running_elbow_angle_degrees: float = 34.0
+    max_running_elbow_angle_degrees: float = 170.0
+    min_circle_root_path_ratio: float = 0.35
+    min_circle_root_turn_degrees: float = 55.0
+    max_running_root_vertical_range_ratio: float = 0.40
 
 
 @dataclass(frozen=True)
@@ -106,6 +120,16 @@ def _is_backflip_prompt(prompt: str | None) -> bool:
 def _is_stationary_prompt(prompt: str | None) -> bool:
     text = (prompt or "").lower()
     return any(token in text for token in ("standing", "stationary", "in place", "原地"))
+
+
+def _is_running_prompt(prompt: str | None) -> bool:
+    text = (prompt or "").lower()
+    return any(token in text for token in ("run", "running", "jog", "jogging", "跑步", "慢跑", "小跑"))
+
+
+def _is_circle_prompt(prompt: str | None) -> bool:
+    text = (prompt or "").lower()
+    return any(token in text for token in ("circle", "loop", "circular", "绕圈", "小圈", "转圈", "环形"))
 
 
 def _finite_or_default(value: float | None, default: float = 0.0) -> float:
@@ -286,6 +310,76 @@ def _self_contact_metrics(points: np.ndarray, body_height: float) -> dict[str, f
     }
 
 
+def _correlation_or_zero(a: np.ndarray, b: np.ndarray) -> float:
+    if len(a) < 3 or len(b) < 3:
+        return 0.0
+    if float(np.nanstd(a)) < 1e-6 or float(np.nanstd(b)) < 1e-6:
+        return 0.0
+    corr = np.corrcoef(a, b)[0, 1]
+    return _finite_or_default(float(corr))
+
+
+def _arm_swing_metrics(points: np.ndarray, body_height: float) -> dict[str, float]:
+    local_hands: dict[str, list[np.ndarray]] = {"Left": [], "Right": []}
+    local_ankles: dict[str, list[np.ndarray]] = {"Left": [], "Right": []}
+    elbow_angles: list[float] = []
+
+    for frame in points:
+        basis = _orthonormal_body_basis(frame)
+        if basis is None:
+            continue
+        torso_origin = frame[9] if len(frame) > 9 else frame[0]
+        pelvis = frame[0]
+        for side in ("Left", "Right"):
+            arm = SMPL_ARM_JOINTS[side]
+            leg = SMPL_LEG_JOINTS[side]
+            shoulder = frame[arm["shoulder"]]
+            elbow = frame[arm["elbow"]]
+            hand = frame[arm["hand"]]
+            local_hands[side].append(basis.T @ (hand - torso_origin) / body_height)
+            local_ankles[side].append(basis.T @ (frame[leg["ankle"]] - pelvis) / body_height)
+            elbow_angle = _angle_degrees(shoulder - elbow, hand - elbow)
+            if elbow_angle is not None:
+                elbow_angles.append(elbow_angle)
+
+    left_hand = np.asarray(local_hands["Left"], dtype=np.float64)
+    right_hand = np.asarray(local_hands["Right"], dtype=np.float64)
+    left_ankle = np.asarray(local_ankles["Left"], dtype=np.float64)
+    right_ankle = np.asarray(local_ankles["Right"], dtype=np.float64)
+
+    if len(left_hand) == 0 or len(right_hand) == 0 or len(left_ankle) == 0 or len(right_ankle) == 0:
+        return {
+            "arm_forward_range_ratio": 0.0,
+            "hand_lateral_p95_ratio": 0.0,
+            "arm_leg_counterphase": 0.0,
+            "hand_opposition": 0.0,
+            "elbow_angle_min_degrees": 0.0,
+            "elbow_angle_max_degrees": 0.0,
+            "elbow_angle_median_degrees": 0.0,
+        }
+
+    hand_forward_ranges = [
+        float(np.nanmax(hand[:, 2]) - np.nanmin(hand[:, 2]))
+        for hand in (left_hand, right_hand)
+        if len(hand)
+    ]
+    hand_lateral = np.abs(np.concatenate([left_hand[:, 0], right_hand[:, 0]]))
+    hand_diff = left_hand[:, 2] - right_hand[:, 2]
+    leg_diff = left_ankle[:, 2] - right_ankle[:, 2]
+    hand_opposition = -_correlation_or_zero(left_hand[:, 2], right_hand[:, 2])
+    arm_leg_counterphase = -_correlation_or_zero(hand_diff, leg_diff)
+
+    return {
+        "arm_forward_range_ratio": float(np.nanmean(hand_forward_ranges)) if hand_forward_ranges else 0.0,
+        "hand_lateral_p95_ratio": float(np.nanpercentile(hand_lateral, 95)) if len(hand_lateral) else 0.0,
+        "arm_leg_counterphase": arm_leg_counterphase,
+        "hand_opposition": hand_opposition,
+        "elbow_angle_min_degrees": float(np.nanmin(elbow_angles)) if elbow_angles else 0.0,
+        "elbow_angle_max_degrees": float(np.nanmax(elbow_angles)) if elbow_angles else 0.0,
+        "elbow_angle_median_degrees": float(np.nanmedian(elbow_angles)) if elbow_angles else 0.0,
+    }
+
+
 def _shape_jerk(points: np.ndarray, body_height: float) -> float:
     local = points - points[:, :1]
     acceleration = np.diff(local, n=2, axis=0)
@@ -303,6 +397,51 @@ def _root_drift_ratio(clip: MotionClip, frames: int, body_height: float) -> floa
     horizontal = root[:, [0, 2]]
     drift = float(np.linalg.norm(horizontal[-1] - horizontal[0]))
     return drift / body_height
+
+
+def _root_locomotion_metrics(clip: MotionClip, frames: int, body_height: float) -> dict[str, float | bool]:
+    root = resample_motion(clip, frames).root_positions
+    if root is None or len(root) < 2:
+        return {
+            "has_root_positions": False,
+            "root_path_length_ratio": 0.0,
+            "root_net_displacement_ratio": 0.0,
+            "root_loop_ratio": 0.0,
+            "root_horizontal_span_ratio": 0.0,
+            "root_abs_turn_degrees": 0.0,
+            "root_signed_turn_degrees": 0.0,
+            "root_vertical_range_ratio": 0.0,
+        }
+
+    horizontal = np.asarray(root[:, :2], dtype=np.float64)
+    if horizontal.shape[1] == 1:
+        horizontal = np.column_stack([horizontal[:, 0], np.zeros(len(horizontal), dtype=np.float64)])
+    diffs = np.diff(horizontal, axis=0)
+    segment_lengths = np.linalg.norm(diffs, axis=1)
+    path_length = float(np.nansum(segment_lengths))
+    net_displacement = float(np.linalg.norm(horizontal[-1] - horizontal[0]))
+    span = float(np.linalg.norm(np.nanmax(horizontal, axis=0) - np.nanmin(horizontal, axis=0)))
+    valid = segment_lengths > 1e-8
+    abs_turn = 0.0
+    signed_turn = 0.0
+    if int(np.count_nonzero(valid)) > 1:
+        dirs = diffs[valid] / (segment_lengths[valid, None] + 1e-12)
+        cross = dirs[:-1, 0] * dirs[1:, 1] - dirs[:-1, 1] * dirs[1:, 0]
+        dot = np.sum(dirs[:-1] * dirs[1:], axis=1)
+        angles = np.arctan2(cross, np.clip(dot, -1.0, 1.0))
+        abs_turn = float(np.degrees(np.nansum(np.abs(angles))))
+        signed_turn = float(np.degrees(np.nansum(angles)))
+    vertical = np.asarray(root[:, 2], dtype=np.float64) if root.shape[1] >= 3 else np.zeros(len(root), dtype=np.float64)
+    return {
+        "has_root_positions": True,
+        "root_path_length_ratio": path_length / body_height,
+        "root_net_displacement_ratio": net_displacement / body_height,
+        "root_loop_ratio": net_displacement / max(path_length, 1e-8),
+        "root_horizontal_span_ratio": span / body_height,
+        "root_abs_turn_degrees": abs_turn,
+        "root_signed_turn_degrees": signed_turn,
+        "root_vertical_range_ratio": float(np.nanmax(vertical) - np.nanmin(vertical)) / body_height,
+    }
 
 
 def score_motion_clip(
@@ -333,8 +472,10 @@ def score_motion_clip(
     metrics.update(_backflip_metrics(points))
     metrics.update(_leg_metrics(points, body_height))
     metrics.update(_self_contact_metrics(points, body_height))
+    metrics.update(_arm_swing_metrics(points, body_height))
     metrics["shape_jerk"] = _shape_jerk(points, body_height)
     metrics["root_drift_ratio"] = _root_drift_ratio(clip, options.frames, body_height)
+    metrics.update(_root_locomotion_metrics(clip, options.frames, body_height))
 
     score = 100.0
     if finite_ratio < 0.999:
@@ -415,6 +556,49 @@ def score_motion_clip(
         if drift > options.max_root_drift_ratio:
             score -= (drift - options.max_root_drift_ratio) * 18.0
             reasons.append("root drifts too far for a stationary prompt")
+
+    if _is_running_prompt(prompt or clip.prompt):
+        arm_range = float(metrics["arm_forward_range_ratio"])
+        hand_lateral = float(metrics["hand_lateral_p95_ratio"])
+        counterphase = float(metrics["arm_leg_counterphase"])
+        hand_opposition = float(metrics["hand_opposition"])
+        elbow_min = float(metrics["elbow_angle_min_degrees"])
+        elbow_max = float(metrics["elbow_angle_max_degrees"])
+        if arm_range < options.min_running_arm_forward_range_ratio:
+            score -= (options.min_running_arm_forward_range_ratio - arm_range) * 160.0
+            reasons.append("running arms do not swing forward/back enough")
+        if hand_lateral > options.max_running_hand_lateral_p95_ratio:
+            score -= (hand_lateral - options.max_running_hand_lateral_p95_ratio) * 45.0
+            reasons.append("running hands are held too wide from the torso")
+        if counterphase < options.min_running_arm_leg_counterphase:
+            score -= (options.min_running_arm_leg_counterphase - counterphase) * 18.0
+            reasons.append("running arm swing is not counter-phased with the legs")
+        if hand_opposition < options.min_running_hand_opposition:
+            score -= (options.min_running_hand_opposition - hand_opposition) * 16.0
+            reasons.append("left and right running arms do not alternate cleanly")
+        if elbow_min < options.min_running_elbow_angle_degrees:
+            score -= (options.min_running_elbow_angle_degrees - elbow_min) * 0.35
+            reasons.append("running elbows fold too tightly")
+        if elbow_max > options.max_running_elbow_angle_degrees:
+            score -= (elbow_max - options.max_running_elbow_angle_degrees) * 0.28
+            reasons.append("running elbows straighten too much")
+        root_vertical = float(metrics["root_vertical_range_ratio"])
+        if root_vertical > options.max_running_root_vertical_range_ratio:
+            score -= (root_vertical - options.max_running_root_vertical_range_ratio) * 35.0
+            reasons.append("running root moves vertically too much")
+
+    if _is_circle_prompt(prompt or clip.prompt):
+        root_path = float(metrics["root_path_length_ratio"])
+        root_turn = float(metrics["root_abs_turn_degrees"])
+        if not bool(metrics["has_root_positions"]):
+            score -= 6.0
+            reasons.append("circle prompt has no root path to evaluate")
+        if root_path < options.min_circle_root_path_ratio:
+            score -= (options.min_circle_root_path_ratio - root_path) * 30.0
+            reasons.append("circle running root path is too short")
+        if root_turn < options.min_circle_root_turn_degrees:
+            score -= (options.min_circle_root_turn_degrees - root_turn) * 0.08
+            reasons.append("circle running root path does not turn enough")
 
     if float(metrics["leg_reach_ratio_min"]) < options.min_leg_reach_ratio:
         reasons.append("leg chain collapses too tightly")

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -67,6 +67,8 @@ class AvatarActionRequest:
     calibrated_leg_ik: bool = True
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
+    procedural_running_arm_swing: bool = True
+    running_arm_swing_strength: float = 0.88
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
     hair_shell_thickness: float = 0.006
@@ -131,6 +133,8 @@ class AvatarActionPipeline:
             calibrated_leg_ik=request.calibrated_leg_ik,
             body_relative_leg_ik=request.body_relative_leg_ik,
             prefer_joint_position_ik=request.prefer_joint_position_ik,
+            procedural_running_arm_swing=request.procedural_running_arm_swing,
+            running_arm_swing_strength=request.running_arm_swing_strength,
             solidify_shell=request.solidify_shell,
             body_shell_thickness=request.body_shell_thickness,
             hair_shell_thickness=request.hair_shell_thickness,

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -74,6 +74,9 @@ class AvatarActionRequest:
     running_arm_side_ratio: float = 0.055
     running_arm_reach_min: float = 0.46
     running_arm_reach_max: float = 0.68
+    locomotion_torso_counter_rotation: bool = True
+    torso_counter_rotation_degrees: float = 7.0
+    torso_counter_rotation_strength: float = 0.45
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
     hair_shell_thickness: float = 0.006
@@ -145,6 +148,9 @@ class AvatarActionPipeline:
             running_arm_side_ratio=request.running_arm_side_ratio,
             running_arm_reach_min=request.running_arm_reach_min,
             running_arm_reach_max=request.running_arm_reach_max,
+            locomotion_torso_counter_rotation=request.locomotion_torso_counter_rotation,
+            torso_counter_rotation_degrees=request.torso_counter_rotation_degrees,
+            torso_counter_rotation_strength=request.torso_counter_rotation_strength,
             solidify_shell=request.solidify_shell,
             body_shell_thickness=request.body_shell_thickness,
             hair_shell_thickness=request.hair_shell_thickness,

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -57,6 +57,10 @@ class AvatarActionRequest:
     foot_contact_velocity: float = 0.02
     foot_contact_use_source: bool = True
     foot_lock_blend_frames: int = 4
+    grounded_foot_ik: bool = True
+    foot_support_min_frames: int = 8
+    foot_support_max_frames: int = 16
+    foot_support_max_air_frames: int = 8
     airborne_leg_stabilization: bool = False
     airborne_leg_stabilization_strength: float = 0.85
     airborne_tuck_reach_ratio: float = 0.52
@@ -117,6 +121,10 @@ class AvatarActionPipeline:
             foot_contact_velocity=request.foot_contact_velocity,
             foot_contact_use_source=request.foot_contact_use_source,
             foot_lock_blend_frames=request.foot_lock_blend_frames,
+            grounded_foot_ik=request.grounded_foot_ik,
+            foot_support_min_frames=request.foot_support_min_frames,
+            foot_support_max_frames=request.foot_support_max_frames,
+            foot_support_max_air_frames=request.foot_support_max_air_frames,
             airborne_leg_stabilization=request.airborne_leg_stabilization,
             airborne_leg_stabilization_strength=request.airborne_leg_stabilization_strength,
             airborne_tuck_reach_ratio=request.airborne_tuck_reach_ratio,

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from havln3.avatar_assets import select_avatar
+from havln3.motion import generate_kimodo_motion_candidates, load_motion_file
+from havln3.motion_quality import MotionQualityOptions, rank_motion_files, write_motion_quality_report
+from havln3.retarget import RetargetOptions, retarget_motion_to_avatar
+
+
+def _slugify(text: str, *, max_length: int = 72) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", text.lower()).strip("_")
+    slug = re.sub(r"_+", "_", slug)
+    return (slug[:max_length].strip("_") or "avatar_action")
+
+
+@dataclass(frozen=True)
+class AvatarActionRequest:
+    prompt: str
+    output_root: Path
+    avatar_root: Path = Path("vico_assets_probe/models")
+    avatar_glb: Path | None = None
+    avatar_catalog: Path | None = None
+    motion_npz: Path | None = None
+    amass_npz: Path | None = None
+    gem_smpl_params: Path | None = None
+    gem_param_group: str = "body_params_global"
+    asset_name: str | None = None
+    identity: str | None = None
+    generator: str = "existing"
+    kimodo_model: str = "Kimodo-SMPLX-RP-v1"
+    kimodo_num_samples: int = 1
+    motion_quality_select: bool = True
+    motion_quality_min_score: float = 62.0
+    duration: float = 5.0
+    seed: int | None = None
+    frames: int = 120
+    fps: int = 24
+    target_height: float = 1.72
+    ground_y: float = -0.2
+    rotation_scale: float = 0.65
+    arm_rotation_scale: float = 0.65
+    forearm_rotation_scale: float = 0.45
+    hand_rotation_scale: float = 0.18
+    lower_leg_rotation_scale: float = 0.18
+    foot_rotation_scale: float = 0.35
+    include_root_orientation: bool = True
+    preserve_root_motion: bool = False
+    root_motion_scale: float = 1.0
+    stabilize_root_yaw: bool = False
+    foot_contact_lock: bool = False
+    foot_orientation_lock: bool = True
+    foot_contact_height: float = 0.12
+    foot_contact_velocity: float = 0.02
+    foot_contact_use_source: bool = True
+    foot_lock_blend_frames: int = 4
+    airborne_leg_stabilization: bool = False
+    airborne_leg_stabilization_strength: float = 0.85
+    airborne_tuck_reach_ratio: float = 0.52
+    calibrated_leg_ik: bool = True
+    body_relative_leg_ik: bool = False
+    prefer_joint_position_ik: bool = False
+    solidify_shell: bool = True
+    body_shell_thickness: float = 0.018
+    hair_shell_thickness: float = 0.006
+
+
+@dataclass(frozen=True)
+class AvatarActionResult:
+    asset_name: str
+    asset_dir: Path
+    avatar_glb: Path
+    motion_path: Path
+    report_path: Path
+    skeleton_path: Path
+
+
+class AvatarActionPipeline:
+    def run(self, request: AvatarActionRequest) -> AvatarActionResult:
+        avatar_match, top_matches = select_avatar(
+            request.prompt,
+            request.avatar_root,
+            preferred_avatar=request.avatar_glb,
+            catalog_path=request.avatar_catalog,
+        )
+        avatar = avatar_match.asset
+        asset_name = request.asset_name or _slugify(f"{avatar.display_name}_{request.prompt}")
+        asset_dir = request.output_root / "Data" / "HAPS2_0" / asset_name
+        motion_path, amass_path, motion_selection = self._resolve_motion(request, asset_name)
+        motion = load_motion_file(
+            motion_path,
+            amass_path=amass_path,
+            gem_param_group=request.gem_param_group,
+        )
+        identity = request.identity or avatar.display_name
+        options = RetargetOptions(
+            frames=request.frames,
+            fps=request.fps,
+            target_height=request.target_height,
+            ground_y=request.ground_y,
+            rotation_scale=request.rotation_scale,
+            arm_rotation_scale=request.arm_rotation_scale,
+            forearm_rotation_scale=request.forearm_rotation_scale,
+            hand_rotation_scale=request.hand_rotation_scale,
+            lower_leg_rotation_scale=request.lower_leg_rotation_scale,
+            foot_rotation_scale=request.foot_rotation_scale,
+            include_root_orientation=request.include_root_orientation,
+            preserve_root_motion=request.preserve_root_motion,
+            root_motion_scale=request.root_motion_scale,
+            stabilize_root_yaw=request.stabilize_root_yaw,
+            foot_contact_lock=request.foot_contact_lock,
+            foot_orientation_lock=request.foot_orientation_lock,
+            foot_contact_height=request.foot_contact_height,
+            foot_contact_velocity=request.foot_contact_velocity,
+            foot_contact_use_source=request.foot_contact_use_source,
+            foot_lock_blend_frames=request.foot_lock_blend_frames,
+            airborne_leg_stabilization=request.airborne_leg_stabilization,
+            airborne_leg_stabilization_strength=request.airborne_leg_stabilization_strength,
+            airborne_tuck_reach_ratio=request.airborne_tuck_reach_ratio,
+            calibrated_leg_ik=request.calibrated_leg_ik,
+            body_relative_leg_ik=request.body_relative_leg_ik,
+            prefer_joint_position_ik=request.prefer_joint_position_ik,
+            solidify_shell=request.solidify_shell,
+            body_shell_thickness=request.body_shell_thickness,
+            hair_shell_thickness=request.hair_shell_thickness,
+        )
+        selection = {
+            "selected": {
+                "path": str(avatar.path),
+                "display_name": avatar.display_name,
+                "provider": avatar.provider,
+                "score": avatar_match.score,
+                "reasons": list(avatar_match.reasons),
+                "tags": sorted(avatar.tags),
+            },
+            "top_candidates": [
+                {
+                    "path": str(match.asset.path),
+                    "display_name": match.asset.display_name,
+                    "score": match.score,
+                    "reasons": list(match.reasons),
+                }
+                for match in top_matches
+            ],
+            "motion": motion_selection,
+        }
+        report = retarget_motion_to_avatar(
+            avatar_glb=avatar.path,
+            motion=motion,
+            output_dir=asset_dir,
+            asset_name=asset_name,
+            prompt=request.prompt,
+            identity=identity,
+            options=options,
+            selection=selection,
+        )
+        report_dir = request.output_root / "reports"
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_path = report_dir / f"{asset_name}_retarget_report.json"
+        report_path.write_text(json.dumps({**report, "selection": selection}, indent=2), encoding="utf-8")
+        return AvatarActionResult(
+            asset_name=asset_name,
+            asset_dir=asset_dir,
+            avatar_glb=avatar.path,
+            motion_path=motion_path,
+            report_path=report_path,
+            skeleton_path=asset_dir / "skeleton.json",
+        )
+
+    def _resolve_motion(
+        self,
+        request: AvatarActionRequest,
+        asset_name: str,
+    ) -> tuple[Path, Path | None, dict[str, object]]:
+        if request.motion_npz:
+            return request.motion_npz, request.amass_npz, {
+                "mode": "provided",
+                "selected": str(request.motion_npz),
+                "amass": str(request.amass_npz) if request.amass_npz else None,
+            }
+        if request.gem_smpl_params:
+            return request.gem_smpl_params, None, {
+                "mode": "provided_gem",
+                "selected": str(request.gem_smpl_params),
+                "amass": None,
+            }
+        if request.generator == "kimodo":
+            output_stem = request.output_root / "motion_generation" / asset_name / asset_name
+            generated = generate_kimodo_motion_candidates(
+                request.prompt,
+                output_stem,
+                model=request.kimodo_model,
+                duration=request.duration,
+                seed=request.seed,
+                num_samples=request.kimodo_num_samples,
+            )
+            if not generated:
+                raise RuntimeError(f"Kimodo did not produce .npz motion files under {output_stem.parent}")
+            if len(generated) == 1 or not request.motion_quality_select:
+                selected, amass = generated[0]
+                return selected, amass, {
+                    "mode": "kimodo",
+                    "quality_select": False,
+                    "selected": str(selected),
+                    "amass": str(amass) if amass else None,
+                    "candidates": [str(path) for path, _ in generated],
+                }
+
+            amass_by_motion = {motion_path: amass_path for motion_path, amass_path in generated}
+            quality_options = MotionQualityOptions(min_score=request.motion_quality_min_score)
+            quality_reports = rank_motion_files(
+                [motion_path for motion_path, _ in generated],
+                prompt=request.prompt,
+                options=quality_options,
+                gem_param_group=request.gem_param_group,
+            )
+            quality_report_path = output_stem.parent / "motion_quality_report.json"
+            write_motion_quality_report(quality_report_path, quality_reports)
+            best = quality_reports[0]
+            best_path = Path(best.path)
+            return best_path, amass_by_motion.get(best_path), {
+                "mode": "kimodo",
+                "quality_select": True,
+                "selected": str(best_path),
+                "amass": str(amass_by_motion.get(best_path)) if amass_by_motion.get(best_path) else None,
+                "quality_report": str(quality_report_path),
+                "best_score": best.score,
+                "best_passed": best.passed,
+                "best_reasons": best.reasons,
+                "candidate_count": len(quality_reports),
+            }
+        raise ValueError(
+            "No motion source was provided. Pass --motion-npz/--gem-smpl-params, "
+            "or use --generator kimodo in an environment where kimodo_gen is installed."
+        )

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -67,14 +67,14 @@ class AvatarActionRequest:
     calibrated_leg_ik: bool = True
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
-    procedural_running_arm_swing: bool = True
+    procedural_running_arm_swing: bool = False
     running_arm_swing_strength: float = 0.35
     running_arm_forward_ratio: float = 0.52
     running_arm_drop_ratio: float = 0.50
     running_arm_side_ratio: float = 0.055
     running_arm_reach_min: float = 0.46
     running_arm_reach_max: float = 0.68
-    locomotion_torso_counter_rotation: bool = True
+    locomotion_torso_counter_rotation: bool = False
     torso_counter_rotation_degrees: float = 7.0
     torso_counter_rotation_strength: float = 0.45
     solidify_shell: bool = True

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -65,6 +65,7 @@ class AvatarActionRequest:
     airborne_leg_stabilization_strength: float = 0.85
     airborne_tuck_reach_ratio: float = 0.52
     calibrated_leg_ik: bool = True
+    calibrated_arm_ik: bool = True
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
     procedural_running_arm_swing: bool = False
@@ -139,6 +140,7 @@ class AvatarActionPipeline:
             airborne_leg_stabilization_strength=request.airborne_leg_stabilization_strength,
             airborne_tuck_reach_ratio=request.airborne_tuck_reach_ratio,
             calibrated_leg_ik=request.calibrated_leg_ik,
+            calibrated_arm_ik=request.calibrated_arm_ik,
             body_relative_leg_ik=request.body_relative_leg_ik,
             prefer_joint_position_ik=request.prefer_joint_position_ik,
             procedural_running_arm_swing=request.procedural_running_arm_swing,

--- a/src/havln3/pipeline.py
+++ b/src/havln3/pipeline.py
@@ -68,7 +68,12 @@ class AvatarActionRequest:
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
     procedural_running_arm_swing: bool = True
-    running_arm_swing_strength: float = 0.88
+    running_arm_swing_strength: float = 0.35
+    running_arm_forward_ratio: float = 0.52
+    running_arm_drop_ratio: float = 0.50
+    running_arm_side_ratio: float = 0.055
+    running_arm_reach_min: float = 0.46
+    running_arm_reach_max: float = 0.68
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
     hair_shell_thickness: float = 0.006
@@ -135,6 +140,11 @@ class AvatarActionPipeline:
             prefer_joint_position_ik=request.prefer_joint_position_ik,
             procedural_running_arm_swing=request.procedural_running_arm_swing,
             running_arm_swing_strength=request.running_arm_swing_strength,
+            running_arm_forward_ratio=request.running_arm_forward_ratio,
+            running_arm_drop_ratio=request.running_arm_drop_ratio,
+            running_arm_side_ratio=request.running_arm_side_ratio,
+            running_arm_reach_min=request.running_arm_reach_min,
+            running_arm_reach_max=request.running_arm_reach_max,
             solidify_shell=request.solidify_shell,
             body_shell_thickness=request.body_shell_thickness,
             hair_shell_thickness=request.hair_shell_thickness,

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -92,6 +92,10 @@ class RetargetOptions:
     foot_contact_velocity: float = 0.02
     foot_contact_use_source: bool = True
     foot_lock_blend_frames: int = 4
+    grounded_foot_ik: bool = True
+    foot_support_min_frames: int = 8
+    foot_support_max_frames: int = 16
+    foot_support_max_air_frames: int = 8
     airborne_leg_stabilization: bool = False
     airborne_leg_stabilization_strength: float = 0.85
     airborne_tuck_reach_ratio: float = 0.52
@@ -954,6 +958,123 @@ def _foot_contact_analysis(
     )
 
 
+def _max_airborne_gap(contact_mask: np.ndarray) -> int:
+    support = contact_mask.any(axis=1)
+    return max((end - start + 1 for start, end in _contiguous_segments(~support)), default=0)
+
+
+def _split_long_segment(start: int, end: int, max_frames: int) -> list[tuple[int, int]]:
+    if max_frames <= 1 or end - start + 1 <= max_frames:
+        return [(start, end)]
+    segments: list[tuple[int, int]] = []
+    cursor = start
+    while cursor <= end:
+        segment_end = min(end, cursor + max_frames - 1)
+        segments.append((cursor, segment_end))
+        cursor = segment_end + 1
+    return segments
+
+
+def _expand_support_contact_mask(
+    analysis: FootContactAnalysis,
+    *,
+    fps: int,
+    ground_y: float,
+    contact_height: float,
+    min_segment_frames: int,
+    max_air_frames: int,
+) -> np.ndarray:
+    frame_count = len(analysis.contact_mask)
+    if frame_count == 0:
+        return analysis.contact_mask.copy()
+
+    min_segment_frames = max(2, int(min_segment_frames))
+    pre_frames = max(2, min_segment_frames // 2)
+    post_frames = max(pre_frames + 1, min_segment_frames)
+    min_gap = max(min_segment_frames, int(round(max(fps, 1) * 0.16)))
+    height_ceiling = ground_y + max(contact_height * 2.5, 0.08)
+
+    expanded = np.zeros_like(analysis.contact_mask, dtype=bool)
+    for side_index in range(2):
+        raw_side = analysis.contact_mask[:, side_index]
+        for start, end in _contiguous_segments(raw_side):
+            span = end - start + 1
+            if span < min_segment_frames:
+                pad = min_segment_frames - span
+                start = max(0, start - (pad + 1) // 2)
+                end = min(frame_count - 1, end + pad // 2)
+            expanded[start : end + 1, side_index] = True
+
+        lows = analysis.lows[:, side_index]
+        finite = np.isfinite(lows)
+        candidates: list[int] = []
+        for frame_index in range(frame_count):
+            if not finite[frame_index] or lows[frame_index] > height_ceiling:
+                continue
+            start = max(0, frame_index - 2)
+            end = min(frame_count, frame_index + 3)
+            window = lows[start:end][finite[start:end]]
+            if len(window) and lows[frame_index] <= np.nanmin(window) + 1e-6:
+                candidates.append(frame_index)
+
+        selected: list[int] = []
+        for frame_index in candidates:
+            if not selected or frame_index - selected[-1] >= min_gap:
+                selected.append(frame_index)
+            elif lows[frame_index] < lows[selected[-1]]:
+                selected[-1] = frame_index
+
+        for frame_index in selected:
+            start = max(0, frame_index - pre_frames)
+            end = min(frame_count - 1, frame_index + post_frames)
+            expanded[start : end + 1, side_index] = True
+
+    for frame_index in range(frame_count):
+        if expanded[frame_index].sum() <= 1:
+            continue
+        side_scores = analysis.lows[frame_index].copy()
+        finite = np.isfinite(side_scores)
+        if not finite.any():
+            expanded[frame_index] = False
+            continue
+        speeds = analysis.speeds[frame_index]
+        if np.isfinite(speeds).any():
+            speed_penalty = np.nan_to_num(
+                speeds,
+                nan=float(np.nanmax(speeds[np.isfinite(speeds)])),
+            )
+            side_scores = side_scores + speed_penalty * 0.35
+        side_scores[~finite] = np.inf
+        keep = int(np.argmin(side_scores))
+        expanded[frame_index] = False
+        expanded[frame_index, keep] = True
+
+    max_air_frames = max(0, int(max_air_frames))
+    if max_air_frames > 0:
+        for _ in range(frame_count):
+            gaps = [
+                (start, end)
+                for start, end in _contiguous_segments(~expanded.any(axis=1))
+                if end - start + 1 > max_air_frames
+            ]
+            if not gaps:
+                break
+            for start, end in gaps:
+                gap_lows = analysis.lows[start : end + 1]
+                finite = np.isfinite(gap_lows)
+                if not finite.any():
+                    continue
+                flat_index = int(np.argmin(np.where(finite, gap_lows, np.inf)))
+                local_frame, side_index = np.unravel_index(flat_index, gap_lows.shape)
+                frame_index = start + int(local_frame)
+                support_start = max(start, frame_index - pre_frames)
+                support_end = min(end, support_start + min_segment_frames - 1)
+                support_start = max(start, support_end - min_segment_frames + 1)
+                expanded[support_start : support_end + 1, side_index] = True
+
+    return expanded
+
+
 def _smooth_unit_vectors(vectors: np.ndarray, valid: np.ndarray, *, radius: int = 2) -> np.ndarray:
     smoothed = vectors.copy()
     for index in range(len(vectors)):
@@ -1336,11 +1457,317 @@ def _apply_contact_foot_orientation_lock(
     }
 
 
+def _target_point_to_source_axes(
+    point: np.ndarray,
+    *,
+    normalizer: VertexNormalizer,
+    root_offset: np.ndarray | None,
+) -> np.ndarray:
+    target = np.asarray(point, dtype=np.float64).copy()
+    if root_offset is not None:
+        target -= np.asarray(root_offset, dtype=np.float64)
+    return np.array(
+        [
+            target[0] / normalizer.scale,
+            target[2] / normalizer.scale,
+            (target[1] - normalizer.target_ground_y) / normalizer.scale
+            + normalizer.source_ground,
+        ],
+        dtype=np.float64,
+    )
+
+
+def _apply_leg_ik_target(
+    *,
+    local: np.ndarray,
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    calibration: LegCalibration,
+    target_ankle: np.ndarray,
+    weight: float,
+    desired_toe_direction: np.ndarray | None,
+    local_rest_rot: dict[int, Rotation],
+) -> bool:
+    weight = float(np.clip(weight, 0.0, 1.0))
+    if weight <= 0.0:
+        return False
+
+    skin = gltf.skins[0]
+    globals_ = node_global_matrices(gltf, local)
+    parent_rot = (
+        _rotation_from_matrix(globals_[calibration.parent_node])
+        if calibration.parent_node is not None
+        else Rotation.identity()
+    )
+    hip_pos = globals_[skin.joints[calibration.hip]][:3, 3]
+    current_ankle = globals_[skin.joints[calibration.ankle]][:3, 3]
+    blended_ankle = current_ankle + (target_ankle - current_ankle) * weight
+    direction = _safe_unit(blended_ankle - hip_pos)
+    if direction is None:
+        return False
+
+    reach_ratio = float(
+        np.linalg.norm(blended_ankle - hip_pos) / (calibration.upper_len + calibration.lower_len)
+    )
+    pole = parent_rot.apply(calibration.rest_pole_parent_local)
+    pole = _projected_unit(pole, direction)
+    if pole is None:
+        knee_pos = globals_[skin.joints[calibration.knee]][:3, 3]
+        pole = _limb_pole(hip_pos, knee_pos, current_ankle)
+        pole = _projected_unit(pole, direction)
+    if pole is None:
+        pole = _fallback_pole(direction)
+
+    knee_pos, ankle_pos = _two_bone_knee_position(
+        hip_pos,
+        direction,
+        pole,
+        upper_len=calibration.upper_len,
+        lower_len=calibration.lower_len,
+        reach_ratio=reach_ratio,
+    )
+
+    desired_upper = knee_pos - hip_pos
+    desired_lower = ankle_pos - knee_pos
+    desired_hip_rot = _basis_rotation(
+        calibration.rest_upper_local,
+        calibration.rest_pole_hip_local,
+        desired_upper,
+        pole,
+    )
+    target_hip_delta = local_rest_rot[calibration.hip].inv() * parent_rot.inv() * desired_hip_rot
+    current_hip_delta = Rotation.from_quat(local[calibration.hip])
+    hip_delta = _blend_rotation(current_hip_delta, target_hip_delta, weight)
+    local[calibration.hip] = hip_delta.as_quat()
+
+    hip_global_rot = parent_rot * local_rest_rot[calibration.hip] * hip_delta
+    desired_knee_rot = _basis_rotation(
+        calibration.rest_lower_local,
+        calibration.rest_pole_knee_local,
+        desired_lower,
+        pole,
+    )
+    target_knee_delta = local_rest_rot[calibration.knee].inv() * hip_global_rot.inv() * desired_knee_rot
+    current_knee_delta = Rotation.from_quat(local[calibration.knee])
+    knee_delta = _blend_rotation(current_knee_delta, target_knee_delta, weight)
+    local[calibration.knee] = knee_delta.as_quat()
+
+    if (
+        desired_toe_direction is not None
+        and calibration.rest_toe_local is not None
+        and calibration.rest_foot_up_local is not None
+    ):
+        globals_ = node_global_matrices(gltf, local)
+        knee_global_rot = _rotation_from_matrix(globals_[skin.joints[calibration.knee]])
+        toe_direction = _projected_unit(desired_toe_direction, GLTF_UP)
+        if toe_direction is not None:
+            desired_foot_rotation = _basis_rotation(
+                calibration.rest_toe_local,
+                calibration.rest_foot_up_local,
+                toe_direction,
+                GLTF_UP,
+            )
+            target_foot_delta = (
+                local_rest_rot[calibration.ankle].inv()
+                * knee_global_rot.inv()
+                * desired_foot_rotation
+            )
+            current_foot_delta = Rotation.from_quat(local[calibration.ankle])
+            local[calibration.ankle] = _blend_rotation(
+                current_foot_delta,
+                target_foot_delta,
+                weight,
+            ).as_quat()
+
+        if calibration.toe is not None:
+            current_toe_delta = Rotation.from_quat(local[calibration.toe])
+            local[calibration.toe] = _blend_rotation(
+                current_toe_delta,
+                Rotation.identity(),
+                weight,
+            ).as_quat()
+
+    return True
+
+
+def _apply_grounded_foot_ik(
+    *,
+    local_quats_by_frame: list[np.ndarray],
+    rough_frames: list[FrameGeometry],
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    calibrations: list[LegCalibration],
+    clip: MotionClip,
+    normalizer: VertexNormalizer,
+    options: RetargetOptions,
+) -> dict[str, Any]:
+    if not calibrations:
+        return {"enabled": True, "ik_frames": 0, "reason": "missing leg calibration"}
+
+    analysis = _foot_contact_analysis(
+        rough_frames,
+        joint_by_name,
+        ground_y=options.ground_y,
+        contact_height=options.foot_contact_height,
+        contact_velocity=options.foot_contact_velocity,
+        source_foot_contacts=clip.foot_contacts,
+        use_source_contacts=options.foot_contact_use_source,
+    )
+    if analysis is None:
+        return {"enabled": True, "ik_frames": 0, "reason": "missing foot joints"}
+
+    support_mask = _expand_support_contact_mask(
+        analysis,
+        fps=options.fps,
+        ground_y=options.ground_y,
+        contact_height=options.foot_contact_height,
+        min_segment_frames=options.foot_support_min_frames,
+        max_air_frames=options.foot_support_max_air_frames,
+    )
+    skin = gltf.skins[0]
+    calibration_by_side = {calibration.side: calibration for calibration in calibrations}
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index)
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    sides = ("Left", "Right")
+    applied_segments: list[dict[str, Any]] = []
+    ik_frames: set[int] = set()
+    side_clearance = np.zeros(2, dtype=np.float64)
+    side_center_offset = np.zeros(2, dtype=np.float64)
+    for side_index in range(2):
+        lows = analysis.lows[:, side_index]
+        centers = analysis.centers[:, side_index]
+        finite_low = np.isfinite(lows)
+        if finite_low.any():
+            clearance = float(np.nanpercentile(lows[finite_low] - options.ground_y, 5.0))
+            side_clearance[side_index] = float(
+                np.clip(clearance, 0.0, max(options.foot_contact_height, 0.02))
+            )
+        valid_center = np.isfinite(centers).all(axis=1) & finite_low
+        if valid_center.any():
+            side_center_offset[side_index] = float(
+                np.nanmedian(centers[valid_center, 1] - lows[valid_center])
+            )
+
+    for side_index, side in enumerate(sides):
+        calibration = calibration_by_side.get(side)
+        if calibration is None:
+            continue
+        side_segments: list[tuple[int, int]] = []
+        for start, end in _contiguous_segments(support_mask[:, side_index]):
+            side_segments.extend(
+                _split_long_segment(start, end, max(2, options.foot_support_max_frames))
+            )
+        for start, end in side_segments:
+            if end - start + 1 < 2:
+                continue
+            centers = analysis.centers[start : end + 1, side_index]
+            lows = analysis.lows[start : end + 1, side_index]
+            speeds = analysis.speeds[start : end + 1, side_index]
+            valid = np.isfinite(centers).all(axis=1) & np.isfinite(lows)
+            if not valid.any():
+                continue
+
+            anchor_xy = np.nanmedian(centers[valid][:, [0, 2]], axis=0)
+            target_center_y = (
+                options.ground_y
+                + side_clearance[side_index]
+                + side_center_offset[side_index]
+            )
+            score = np.abs(lows - (options.ground_y + side_clearance[side_index]))
+            if np.isfinite(speeds).any():
+                speed_fallback = float(np.nanmax(speeds[np.isfinite(speeds)]))
+                score += np.nan_to_num(speeds, nan=speed_fallback) * 4.0
+            score[~valid] = np.inf
+            anchor_frame = int(start + np.argmin(score))
+            anchor_center = np.array([anchor_xy[0], target_center_y, anchor_xy[1]], dtype=np.float64)
+            applied_segments.append(
+                {
+                    "start": int(start),
+                    "end": int(end),
+                    "anchor_frame": anchor_frame,
+                    "side": side,
+                }
+            )
+
+            for frame_index in range(start, end + 1):
+                weight = _edge_blend_weight(
+                    frame_index,
+                    start,
+                    end,
+                    len(local_quats_by_frame),
+                    options.foot_lock_blend_frames,
+                )
+                if weight <= 0.0:
+                    continue
+                local = local_quats_by_frame[frame_index]
+                globals_ = node_global_matrices(gltf, local)
+                ankle = globals_[skin.joints[calibration.ankle]][:3, 3]
+                if calibration.toe is not None:
+                    toe = globals_[skin.joints[calibration.toe]][:3, 3]
+                    current_center = (ankle + toe) * 0.5
+                else:
+                    current_center = ankle
+                root_offset = _root_offset(
+                    clip,
+                    frame_index,
+                    options=options,
+                    normalizer=normalizer,
+                )
+                target_center = _target_point_to_source_axes(
+                    anchor_center,
+                    normalizer=normalizer,
+                    root_offset=root_offset,
+                )
+                target_ankle = target_center - (current_center - ankle)
+                desired_forward = _body_forward_from_globals(globals_, gltf, skin, joint_by_name)
+                if desired_forward is None:
+                    desired_forward = calibration.rest_contact_toe_global
+                if _apply_leg_ik_target(
+                    local=local,
+                    gltf=gltf,
+                    joint_by_name=joint_by_name,
+                    calibration=calibration,
+                    target_ankle=target_ankle,
+                    weight=weight,
+                    desired_toe_direction=desired_forward,
+                    local_rest_rot=local_rest_rot,
+                ):
+                    ik_frames.add(frame_index)
+
+    return {
+        "enabled": True,
+        "ik_frames": len(ik_frames),
+        "segments": applied_segments,
+        "raw_contact_frames_by_side": {
+            "Left": int(analysis.contact_mask[:, 0].sum()),
+            "Right": int(analysis.contact_mask[:, 1].sum()),
+        },
+        "support_frames_by_side": {
+            "Left": int(support_mask[:, 0].sum()),
+            "Right": int(support_mask[:, 1].sum()),
+        },
+        "max_airborne_gap_before": _max_airborne_gap(analysis.contact_mask),
+        "max_airborne_gap_after": _max_airborne_gap(support_mask),
+        "source_contacts_used": analysis.source_contacts_used,
+        "source_contact_ratio": analysis.source_contact_ratio,
+        "strategy": (
+            "expand low-foot gait phases into alternating support windows, pin each support foot "
+            "with target-rig two-bone IK, and align contact foot/toe to body-facing ground plane"
+        ),
+        "blend_frames": options.foot_lock_blend_frames,
+    }
+
+
 def _postprocess_frames(
     frames: list[FrameGeometry],
     joint_by_name: dict[str, int],
     clip: MotionClip,
     options: RetargetOptions,
+    *,
+    apply_contact_lock: bool = True,
 ) -> dict[str, Any]:
     report: dict[str, Any] = {
         "root_yaw_stabilization": {"enabled": False},
@@ -1349,7 +1776,7 @@ def _postprocess_frames(
     }
     if options.stabilize_root_yaw:
         report["root_yaw_stabilization"] = _apply_root_yaw_stabilization(frames, joint_by_name)
-    if options.foot_contact_lock:
+    if options.foot_contact_lock and apply_contact_lock:
         report["foot_contact_lock"] = _apply_foot_contact_lock(
             frames,
             joint_by_name,
@@ -1545,6 +1972,7 @@ def retarget_motion_to_avatar(
     pre_postprocess: dict[str, Any] = {
         "airborne_leg_stabilization": {"enabled": False},
         "foot_orientation_lock": {"enabled": False},
+        "grounded_foot_ik": {"enabled": False},
     }
     if options.airborne_leg_stabilization and leg_ik_enabled:
         rough_frames = _build_frame_geometries(
@@ -1584,6 +2012,29 @@ def retarget_motion_to_avatar(
             options=options,
         )
 
+    grounded_foot_ik_applied = False
+    if options.foot_contact_lock and options.grounded_foot_ik and leg_ik_enabled:
+        rough_frames = _build_frame_geometries(
+            gltf=gltf,
+            skin=skin,
+            local_quats_by_frame=local_quats_by_frame,
+            normalizer=normalizer,
+            clip=clip,
+            options=options,
+        )
+        ground_ik_report = _apply_grounded_foot_ik(
+            local_quats_by_frame=local_quats_by_frame,
+            rough_frames=rough_frames,
+            gltf=gltf,
+            joint_by_name=joint_by_name,
+            calibrations=leg_calibrations,
+            clip=clip,
+            normalizer=normalizer,
+            options=options,
+        )
+        grounded_foot_ik_applied = ground_ik_report.get("ik_frames", 0) > 0
+        pre_postprocess["grounded_foot_ik"] = ground_ik_report
+
     frame_geometries = _build_frame_geometries(
         gltf=gltf,
         skin=skin,
@@ -1592,7 +2043,13 @@ def retarget_motion_to_avatar(
         clip=clip,
         options=options,
     )
-    postprocess = _postprocess_frames(frame_geometries, joint_by_name, clip, options)
+    postprocess = _postprocess_frames(
+        frame_geometries,
+        joint_by_name,
+        clip,
+        options,
+        apply_contact_lock=not grounded_foot_ik_applied,
+    )
     postprocess = {**postprocess, **pre_postprocess}
     skeleton_frames = [
         frame.joints.tolist()

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -1,0 +1,1684 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import trimesh
+from pygltflib import GLTF2
+from scipy.spatial.transform import Rotation
+
+from havln3.gltf_utils import (
+    VertexNormalizer,
+    deform_skinned_primitives,
+    identity_quaternions,
+    joint_base_name,
+    node_global_matrices,
+    write_object_config,
+)
+from havln3.materials import fix_habitat_materials
+from havln3.motion import MotionClip, SMPL22_TO_MIXAMO, resample_motion
+
+
+SMPL22_PARENTS = {
+    0: None,
+    1: 0,
+    2: 0,
+    3: 0,
+    4: 1,
+    5: 2,
+    6: 3,
+    7: 4,
+    8: 5,
+    9: 6,
+    10: 7,
+    11: 8,
+    12: 9,
+    13: 9,
+    14: 9,
+    15: 12,
+    16: 13,
+    17: 14,
+    18: 16,
+    19: 17,
+    20: 18,
+    21: 19,
+}
+
+SMPL22_CHILDREN: dict[int, list[int]] = {index: [] for index in SMPL22_TO_MIXAMO}
+for _child, _parent in SMPL22_PARENTS.items():
+    if _parent is not None:
+        SMPL22_CHILDREN[_parent].append(_child)
+
+
+SMPL_LEG_JOINTS = {
+    "Left": {"hip": 1, "knee": 4, "ankle": 7, "toe": 10},
+    "Right": {"hip": 2, "knee": 5, "ankle": 8, "toe": 11},
+}
+
+GLTF_UP = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+SOURCE_TO_AVATAR_AXES = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0],
+    ],
+    dtype=np.float64,
+)
+
+
+@dataclass(frozen=True)
+class RetargetOptions:
+    frames: int = 120
+    fps: int = 24
+    target_height: float = 1.72
+    ground_y: float = -0.2
+    rotation_scale: float = 0.65
+    arm_rotation_scale: float = 0.65
+    forearm_rotation_scale: float = 0.45
+    hand_rotation_scale: float = 0.18
+    lower_leg_rotation_scale: float = 0.18
+    foot_rotation_scale: float = 0.35
+    include_root_orientation: bool = True
+    preserve_root_motion: bool = False
+    root_motion_scale: float = 1.0
+    snap_to_ground: bool = True
+    stabilize_root_yaw: bool = False
+    foot_contact_lock: bool = False
+    foot_orientation_lock: bool = True
+    foot_contact_height: float = 0.12
+    foot_contact_velocity: float = 0.02
+    foot_contact_use_source: bool = True
+    foot_lock_blend_frames: int = 4
+    airborne_leg_stabilization: bool = False
+    airborne_leg_stabilization_strength: float = 0.85
+    airborne_tuck_reach_ratio: float = 0.52
+    alpha_cutoff: float = 0.55
+    material_roughness: float = 0.88
+    detect_texture_alpha: bool = True
+    calibrated_leg_ik: bool = True
+    body_relative_leg_ik: bool = False
+    prefer_joint_position_ik: bool = False
+    solidify_shell: bool = True
+    body_shell_thickness: float = 0.018
+    hair_shell_thickness: float = 0.006
+
+
+@dataclass(frozen=True)
+class LegCalibration:
+    side: str
+    hip: int
+    knee: int
+    ankle: int
+    toe: int | None
+    parent_node: int | None
+    upper_len: float
+    lower_len: float
+    rest_pole_parent_local: np.ndarray
+    rest_upper_local: np.ndarray
+    rest_lower_local: np.ndarray
+    rest_pole_hip_local: np.ndarray
+    rest_pole_knee_local: np.ndarray
+    rest_pole_foot_local: np.ndarray | None
+    rest_toe_local: np.ndarray | None
+    rest_foot_up_local: np.ndarray | None
+    rest_contact_toe_global: np.ndarray | None
+
+
+@dataclass
+class FrameGeometry:
+    vertices_by_primitive: list[np.ndarray]
+    joints: np.ndarray | None
+
+
+@dataclass(frozen=True)
+class FootContactAnalysis:
+    centers: np.ndarray
+    lows: np.ndarray
+    speeds: np.ndarray
+    contact_mask: np.ndarray
+    segments: list[tuple[int, int]]
+    source_contacts_used: bool
+    source_contact_ratio: list[float]
+
+
+@dataclass(frozen=True)
+class AirborneLegGuide:
+    direction_local: np.ndarray
+    reach_ratio: float
+    skip_foot_ik: bool = True
+
+
+def _scaled_quat_from_matrix(matrix: np.ndarray, scale: float) -> np.ndarray:
+    rotation = Rotation.from_matrix(matrix)
+    if scale != 1.0:
+        rotation = Rotation.from_rotvec(rotation.as_rotvec() * scale)
+    return rotation.as_quat()
+
+
+def _local_quats_for_frame(
+    frame_rot_mats: np.ndarray,
+    joint_by_name: dict[str, int],
+    *,
+    options: RetargetOptions,
+) -> np.ndarray:
+    local = identity_quaternions(len(joint_by_name))
+    for source_index, mixamo_name in SMPL22_TO_MIXAMO.items():
+        if source_index == 0 and not options.include_root_orientation:
+            continue
+        target_index = joint_by_name.get(mixamo_name)
+        if target_index is None:
+            continue
+        scale = options.rotation_scale
+        if mixamo_name in {"LeftArm", "RightArm"}:
+            scale = options.arm_rotation_scale
+        elif mixamo_name in {"LeftForeArm", "RightForeArm"}:
+            scale = options.forearm_rotation_scale
+        elif mixamo_name in {"LeftHand", "RightHand"}:
+            scale = options.hand_rotation_scale
+        elif mixamo_name in {"LeftLeg", "RightLeg"}:
+            scale = options.lower_leg_rotation_scale
+        elif mixamo_name in {"LeftFoot", "RightFoot", "LeftToeBase", "RightToeBase"}:
+            scale = options.foot_rotation_scale
+        local[target_index] = _scaled_quat_from_matrix(frame_rot_mats[source_index], scale)
+    return local
+
+
+def _rotation_from_matrix(matrix: np.ndarray) -> Rotation:
+    rotation = matrix[:3, :3].astype(np.float64)
+    norms = np.linalg.norm(rotation, axis=0)
+    rotation = rotation / np.maximum(norms, 1e-9)
+    return Rotation.from_matrix(rotation)
+
+
+def _local_rest_rotation(gltf: GLTF2, node_index: int) -> Rotation:
+    node = gltf.nodes[node_index]
+    if node.matrix is not None:
+        matrix = np.asarray(node.matrix, dtype=np.float64).reshape(4, 4).T
+        return _rotation_from_matrix(matrix)
+    return Rotation.from_quat(node.rotation or [0.0, 0.0, 0.0, 1.0])
+
+
+def _source_to_avatar_axes(points: np.ndarray) -> np.ndarray:
+    return points[:, [0, 2, 1]]
+
+
+def _source_rotation_to_avatar_axes(matrix: np.ndarray) -> Rotation:
+    return Rotation.from_matrix(SOURCE_TO_AVATAR_AXES @ matrix @ SOURCE_TO_AVATAR_AXES.T)
+
+
+def _safe_unit(vector: np.ndarray) -> np.ndarray | None:
+    norm = float(np.linalg.norm(vector))
+    if norm < 1e-8:
+        return None
+    return vector / norm
+
+
+def _node_parent_indices(gltf: GLTF2) -> dict[int, int]:
+    parents: dict[int, int] = {}
+    for parent_index, node in enumerate(gltf.nodes or []):
+        for child_index in node.children or []:
+            parents[child_index] = parent_index
+    return parents
+
+
+def _projected_unit(vector: np.ndarray, normal: np.ndarray) -> np.ndarray | None:
+    projected = vector - normal * float(np.dot(vector, normal))
+    return _safe_unit(projected)
+
+
+def _orthonormal_body_basis(side: np.ndarray, up_hint: np.ndarray) -> np.ndarray | None:
+    side_unit = _safe_unit(side)
+    if side_unit is None:
+        return None
+    up_unit = _projected_unit(up_hint, side_unit)
+    if up_unit is None:
+        up_unit = _fallback_pole(side_unit)
+    forward_unit = _safe_unit(np.cross(side_unit, up_unit))
+    if forward_unit is None:
+        return None
+    up_unit = _safe_unit(np.cross(forward_unit, side_unit))
+    if up_unit is None:
+        return None
+    return np.column_stack([side_unit, up_unit, forward_unit])
+
+
+def _source_body_basis(source: np.ndarray) -> np.ndarray | None:
+    if len(source) <= 3:
+        return None
+    hips = source[0]
+    side = source[SMPL_LEG_JOINTS["Right"]["hip"]] - source[SMPL_LEG_JOINTS["Left"]["hip"]]
+    for spine_index in (9, 6, 3, 15):
+        if spine_index < len(source):
+            basis = _orthonormal_body_basis(side, source[spine_index] - hips)
+            if basis is not None:
+                return basis
+    return None
+
+
+def _target_body_basis_from_globals(
+    globals_: list[np.ndarray],
+    skin: Any,
+    joint_by_name: dict[str, int],
+) -> np.ndarray | None:
+    hips_index = joint_by_name.get("Hips")
+    left_index = joint_by_name.get("LeftUpLeg")
+    right_index = joint_by_name.get("RightUpLeg")
+    if hips_index is None or left_index is None or right_index is None:
+        return None
+    hips = globals_[skin.joints[hips_index]][:3, 3]
+    left = globals_[skin.joints[left_index]][:3, 3]
+    right = globals_[skin.joints[right_index]][:3, 3]
+    side = right - left
+    for spine_name in ("Spine2", "Spine1", "Spine", "Neck", "Head"):
+        spine_index = joint_by_name.get(spine_name)
+        if spine_index is None:
+            continue
+        basis = _orthonormal_body_basis(side, globals_[skin.joints[spine_index]][:3, 3] - hips)
+        if basis is not None:
+            return basis
+    return None
+
+
+def _fallback_pole(direction: np.ndarray) -> np.ndarray:
+    candidate = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    if abs(float(np.dot(candidate, direction))) > 0.92:
+        candidate = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    pole = _projected_unit(candidate, direction)
+    if pole is None:
+        return np.array([0.0, 1.0, 0.0], dtype=np.float64)
+    return pole
+
+
+def _limb_pole(hip: np.ndarray, knee: np.ndarray, ankle: np.ndarray) -> np.ndarray:
+    line = ankle - hip
+    line_unit = _safe_unit(line)
+    if line_unit is None:
+        return np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    pole = knee - hip - line_unit * float(np.dot(knee - hip, line_unit))
+    pole_unit = _safe_unit(pole)
+    return pole_unit if pole_unit is not None else _fallback_pole(line_unit)
+
+
+def _basis_rotation(
+    rest_primary: np.ndarray,
+    rest_secondary: np.ndarray,
+    desired_primary: np.ndarray,
+    desired_secondary: np.ndarray,
+) -> Rotation:
+    rest_primary_unit = _safe_unit(rest_primary)
+    desired_primary_unit = _safe_unit(desired_primary)
+    if rest_primary_unit is None or desired_primary_unit is None:
+        return Rotation.identity()
+
+    rest_secondary_unit = _projected_unit(rest_secondary, rest_primary_unit)
+    desired_secondary_unit = _projected_unit(desired_secondary, desired_primary_unit)
+    if rest_secondary_unit is None or desired_secondary_unit is None:
+        return Rotation.align_vectors([desired_primary_unit], [rest_primary_unit])[0]
+
+    rest_basis = np.column_stack(
+        [
+            rest_primary_unit,
+            rest_secondary_unit,
+            np.cross(rest_primary_unit, rest_secondary_unit),
+        ]
+    )
+    desired_basis = np.column_stack(
+        [
+            desired_primary_unit,
+            desired_secondary_unit,
+            np.cross(desired_primary_unit, desired_secondary_unit),
+        ]
+    )
+    return Rotation.from_matrix(desired_basis @ rest_basis.T)
+
+
+def _leg_calibrations(
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    rest_globals: list[np.ndarray],
+) -> list[LegCalibration]:
+    skin = gltf.skins[0]
+    parents = _node_parent_indices(gltf)
+    rest_positions = np.stack([rest_globals[joint][:3, 3] for joint in skin.joints])
+    rest_rotations = {
+        skin_index: _rotation_from_matrix(rest_globals[node_index])
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    calibrations: list[LegCalibration] = []
+    for side in ("Left", "Right"):
+        hip = joint_by_name.get(f"{side}UpLeg")
+        knee = joint_by_name.get(f"{side}Leg")
+        ankle = joint_by_name.get(f"{side}Foot")
+        if hip is None or knee is None or ankle is None:
+            continue
+
+        toe = joint_by_name.get(f"{side}ToeBase")
+        hip_pos = rest_positions[hip]
+        knee_pos = rest_positions[knee]
+        ankle_pos = rest_positions[ankle]
+        pole = _limb_pole(hip_pos, knee_pos, ankle_pos)
+        parent_node = parents.get(skin.joints[hip])
+        parent_rot = _rotation_from_matrix(rest_globals[parent_node]) if parent_node is not None else Rotation.identity()
+
+        rest_upper = knee_pos - hip_pos
+        rest_lower = ankle_pos - knee_pos
+        rest_toe = rest_positions[toe] - ankle_pos if toe is not None else None
+        rest_contact_toe = _projected_unit(rest_toe, GLTF_UP) if rest_toe is not None else None
+        calibrations.append(
+            LegCalibration(
+                side=side,
+                hip=hip,
+                knee=knee,
+                ankle=ankle,
+                toe=toe,
+                parent_node=parent_node,
+                upper_len=float(np.linalg.norm(rest_upper)),
+                lower_len=float(np.linalg.norm(rest_lower)),
+                rest_pole_parent_local=parent_rot.inv().apply(pole),
+                rest_upper_local=rest_rotations[hip].inv().apply(rest_upper),
+                rest_lower_local=rest_rotations[knee].inv().apply(rest_lower),
+                rest_pole_hip_local=rest_rotations[hip].inv().apply(pole),
+                rest_pole_knee_local=rest_rotations[knee].inv().apply(pole),
+                rest_pole_foot_local=rest_rotations[ankle].inv().apply(pole) if toe is not None else None,
+                rest_toe_local=rest_rotations[ankle].inv().apply(rest_toe) if rest_toe is not None else None,
+                rest_foot_up_local=rest_rotations[ankle].inv().apply(GLTF_UP) if toe is not None else None,
+                rest_contact_toe_global=rest_contact_toe,
+            )
+        )
+    return calibrations
+
+
+def _two_bone_knee_position(
+    hip: np.ndarray,
+    direction: np.ndarray,
+    pole: np.ndarray,
+    *,
+    upper_len: float,
+    lower_len: float,
+    reach_ratio: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    chain_len = upper_len + lower_len
+    min_reach = abs(upper_len - lower_len) + 1e-5
+    max_reach = max(chain_len - 1e-5, min_reach + 1e-5)
+    reach = float(np.clip(reach_ratio * chain_len, min_reach, max_reach))
+    ankle = hip + direction * reach
+    along = (upper_len**2 - lower_len**2 + reach**2) / (2.0 * reach)
+    height = float(np.sqrt(max(upper_len**2 - along**2, 0.0)))
+    knee = hip + direction * along + pole * height
+    return knee, ankle
+
+
+def _source_body_relative_direction(
+    direction: np.ndarray,
+    *,
+    source_body_basis: np.ndarray | None = None,
+    target_body_basis: np.ndarray | None = None,
+    source_global_rotations: dict[int, Rotation] | None = None,
+    source_parent_index: int | None = None,
+    target_parent_rotation: Rotation = Rotation.identity(),
+) -> np.ndarray | None:
+    direction_unit = _safe_unit(direction)
+    if direction_unit is None:
+        return None
+    if source_body_basis is not None and target_body_basis is not None:
+        local_direction = source_body_basis.T @ direction_unit
+        mapped = target_body_basis @ local_direction
+        mapped_unit = _safe_unit(mapped)
+        return mapped_unit if mapped_unit is not None else direction_unit
+    if source_global_rotations is None or source_parent_index is None:
+        return direction_unit
+    source_parent_rotation = source_global_rotations.get(source_parent_index)
+    if source_parent_rotation is None:
+        return direction_unit
+    local_direction = source_parent_rotation.inv().apply(direction_unit)
+    mapped = target_parent_rotation.apply(local_direction)
+    mapped_unit = _safe_unit(mapped)
+    return mapped_unit if mapped_unit is not None else direction_unit
+
+
+def _apply_calibrated_leg_ik(
+    *,
+    local: np.ndarray,
+    source_joints: np.ndarray,
+    source_global_rot_mats: np.ndarray | None,
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    calibrations: list[LegCalibration],
+    body_relative: bool,
+    leg_guide: dict[str, AirborneLegGuide] | None = None,
+) -> np.ndarray:
+    if not calibrations:
+        return local
+
+    skin = gltf.skins[0]
+    source = _source_to_avatar_axes(source_joints.astype(np.float64))
+    source_basis = _source_body_basis(source) if body_relative else None
+    source_global_rotations: dict[int, Rotation] | None = None
+    if body_relative and source_global_rot_mats is not None:
+        source_global_rotations = {
+            index: _source_rotation_to_avatar_axes(source_global_rot_mats[index].astype(np.float64))
+            for index in range(min(len(source_global_rot_mats), len(SMPL22_TO_MIXAMO)))
+        }
+    current_globals = node_global_matrices(gltf, local)
+    target_basis = _target_body_basis_from_globals(current_globals, skin, joint_by_name) if body_relative else None
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    for calibration in calibrations:
+        source_map = SMPL_LEG_JOINTS[calibration.side]
+        source_hip = source[source_map["hip"]]
+        source_knee = source[source_map["knee"]]
+        source_ankle = source[source_map["ankle"]]
+
+        source_upper_len = float(np.linalg.norm(source_knee - source_hip))
+        source_lower_len = float(np.linalg.norm(source_ankle - source_knee))
+        source_chain_len = source_upper_len + source_lower_len
+        if source_chain_len < 1e-8:
+            continue
+        guide = leg_guide.get(calibration.side) if leg_guide is not None else None
+        reach_ratio = (
+            guide.reach_ratio
+            if guide is not None
+            else float(np.linalg.norm(source_ankle - source_hip) / source_chain_len)
+        )
+
+        parent_rot = (
+            _rotation_from_matrix(current_globals[calibration.parent_node])
+            if calibration.parent_node is not None
+            else Rotation.identity()
+        )
+        if guide is not None and target_basis is not None:
+            source_direction = _safe_unit(target_basis @ guide.direction_local)
+        else:
+            source_direction = _source_body_relative_direction(
+                source_ankle - source_hip,
+                source_body_basis=source_basis,
+                target_body_basis=target_basis,
+                source_global_rotations=source_global_rotations,
+                source_parent_index=SMPL22_PARENTS[source_map["hip"]],
+                target_parent_rotation=parent_rot,
+            )
+        if source_direction is None:
+            continue
+        pole = parent_rot.apply(calibration.rest_pole_parent_local)
+        pole = _projected_unit(pole, source_direction)
+        if pole is None:
+            source_pole = _limb_pole(source_hip, source_knee, source_ankle)
+            pole = _projected_unit(source_pole, source_direction)
+        if pole is None:
+            pole = _fallback_pole(source_direction)
+
+        hip_pos = current_globals[skin.joints[calibration.hip]][:3, 3]
+        knee_pos, ankle_pos = _two_bone_knee_position(
+            hip_pos,
+            source_direction,
+            pole,
+            upper_len=calibration.upper_len,
+            lower_len=calibration.lower_len,
+            reach_ratio=reach_ratio,
+        )
+
+        desired_upper = knee_pos - hip_pos
+        desired_lower = ankle_pos - knee_pos
+        desired_hip_rot = _basis_rotation(
+            calibration.rest_upper_local,
+            calibration.rest_pole_hip_local,
+            desired_upper,
+            pole,
+        )
+        hip_delta = local_rest_rot[calibration.hip].inv() * parent_rot.inv() * desired_hip_rot
+        local[calibration.hip] = hip_delta.as_quat()
+
+        hip_global_rot = parent_rot * local_rest_rot[calibration.hip] * hip_delta
+        desired_knee_rot = _basis_rotation(
+            calibration.rest_lower_local,
+            calibration.rest_pole_knee_local,
+            desired_lower,
+            pole,
+        )
+        knee_delta = local_rest_rot[calibration.knee].inv() * hip_global_rot.inv() * desired_knee_rot
+        local[calibration.knee] = knee_delta.as_quat()
+
+        if (
+            (guide is None or not guide.skip_foot_ik)
+            and calibration.toe is not None
+            and calibration.rest_toe_local is not None
+            and calibration.rest_pole_foot_local is not None
+        ):
+            source_toe = source[source_map["toe"]]
+            source_toe_direction = _source_body_relative_direction(
+                source_toe - source_ankle,
+                source_body_basis=source_basis,
+                target_body_basis=target_basis,
+                source_global_rotations=source_global_rotations,
+                source_parent_index=source_map["knee"],
+                target_parent_rotation=hip_global_rot * local_rest_rot[calibration.knee] * knee_delta,
+            )
+            if source_toe_direction is not None:
+                knee_global_rot = hip_global_rot * local_rest_rot[calibration.knee] * knee_delta
+                desired_foot_rot = _basis_rotation(
+                    calibration.rest_toe_local,
+                    calibration.rest_pole_foot_local,
+                    source_toe_direction,
+                    pole,
+                )
+                foot_delta = local_rest_rot[calibration.ankle].inv() * knee_global_rot.inv() * desired_foot_rot
+                local[calibration.ankle] = foot_delta.as_quat()
+
+    return local
+
+
+def _ik_local_quats_for_frame(
+    source_joints: np.ndarray,
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+) -> np.ndarray:
+    skin = gltf.skins[0]
+    local = identity_quaternions(len(joint_by_name))
+    source = _source_to_avatar_axes(source_joints.astype(np.float64))
+
+    rest_globals = node_global_matrices(gltf, local)
+    rest_positions = np.stack([rest_globals[joint][:3, 3] for joint in skin.joints])
+    rest_global_rot = {
+        skin_index: _rotation_from_matrix(rest_globals[node_index])
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    global_rot: dict[int, Rotation] = {}
+    source_index_by_name = {name: index for index, name in SMPL22_TO_MIXAMO.items()}
+    for source_index in range(len(SMPL22_TO_MIXAMO)):
+        name = SMPL22_TO_MIXAMO[source_index]
+        skin_index = joint_by_name.get(name)
+        if skin_index is None:
+            continue
+
+        parent_source = SMPL22_PARENTS[source_index]
+        if parent_source is not None:
+            parent_name = SMPL22_TO_MIXAMO[parent_source]
+            parent_skin_index = joint_by_name.get(parent_name)
+            parent_rot = global_rot.get(parent_skin_index, Rotation.identity())
+        else:
+            parent_rot = Rotation.identity()
+
+        rest_vectors = []
+        posed_vectors = []
+        for child_source in SMPL22_CHILDREN[source_index]:
+            child_name = SMPL22_TO_MIXAMO[child_source]
+            child_skin_index = joint_by_name.get(child_name)
+            if child_skin_index is None or child_name not in source_index_by_name:
+                continue
+            rest_vector_global = rest_positions[child_skin_index] - rest_positions[skin_index]
+            rest_vector_local = rest_global_rot[skin_index].inv().apply(rest_vector_global)
+            posed_vector = source[child_source] - source[source_index]
+            rest_unit = _safe_unit(rest_vector_local)
+            posed_unit = _safe_unit(posed_vector)
+            if rest_unit is None or posed_unit is None:
+                continue
+            rest_vectors.append(rest_unit)
+            posed_vectors.append(posed_unit)
+
+        if rest_vectors:
+            desired_global, _ = Rotation.align_vectors(np.asarray(posed_vectors), np.asarray(rest_vectors))
+            delta = local_rest_rot[skin_index].inv() * parent_rot.inv() * desired_global
+            local[skin_index] = delta.as_quat()
+            global_rot[skin_index] = desired_global
+        else:
+            delta = Rotation.identity()
+            local[skin_index] = delta.as_quat()
+            global_rot[skin_index] = parent_rot * local_rest_rot[skin_index] * delta
+    return local
+
+
+def _source_geometries(avatar_glb: Path) -> list[Any]:
+    scene = trimesh.load(avatar_glb, force="scene")
+    return list(scene.geometry.values())
+
+
+def _root_offset(
+    clip: MotionClip,
+    frame_index: int,
+    *,
+    options: RetargetOptions,
+    normalizer: VertexNormalizer,
+) -> np.ndarray | None:
+    if not options.preserve_root_motion or clip.root_positions is None:
+        return None
+    raw = np.asarray(clip.root_positions[frame_index] - clip.root_positions[0], dtype=np.float64)
+    return raw * options.root_motion_scale * normalizer.scale
+
+
+def _wrap_angle(angle: float) -> float:
+    return float((angle + np.pi) % (2.0 * np.pi) - np.pi)
+
+
+def _translate_frame(frame: FrameGeometry, delta: np.ndarray) -> None:
+    frame.vertices_by_primitive = [vertices + delta for vertices in frame.vertices_by_primitive]
+    if frame.joints is not None:
+        frame.joints = frame.joints + delta
+
+
+def _rotate_y(points: np.ndarray, angle: float, pivot: np.ndarray) -> np.ndarray:
+    rotation = Rotation.from_euler("y", angle).as_matrix()
+    return (points - pivot) @ rotation.T + pivot
+
+
+def _rotate_frame_y(frame: FrameGeometry, angle: float, pivot: np.ndarray) -> None:
+    frame.vertices_by_primitive = [_rotate_y(vertices, angle, pivot) for vertices in frame.vertices_by_primitive]
+    if frame.joints is not None:
+        frame.joints = _rotate_y(frame.joints, angle, pivot)
+
+
+def _joint_index(joint_by_name: dict[str, int], *names: str) -> int | None:
+    for name in names:
+        index = joint_by_name.get(name)
+        if index is not None:
+            return index
+    return None
+
+
+def _joint_point(
+    joints: np.ndarray,
+    joint_by_name: dict[str, int],
+    *names: str,
+) -> np.ndarray | None:
+    index = _joint_index(joint_by_name, *names)
+    if index is None:
+        return None
+    return joints[index]
+
+
+def _root_yaw_from_joints(joints: np.ndarray, joint_by_name: dict[str, int]) -> float | None:
+    left = _joint_point(joints, joint_by_name, "LeftUpLeg", "LeftLeg", "LeftFoot")
+    right = _joint_point(joints, joint_by_name, "RightUpLeg", "RightLeg", "RightFoot")
+    if left is None or right is None:
+        return None
+    side = right - left
+    side[1] = 0.0
+    side_unit = _safe_unit(side)
+    if side_unit is None:
+        return None
+    return float(np.arctan2(side_unit[2], side_unit[0]))
+
+
+def _body_forward_from_globals(
+    globals_: list[np.ndarray],
+    gltf: GLTF2,
+    skin: Any,
+    joint_by_name: dict[str, int],
+) -> np.ndarray | None:
+    for left_name, right_name in (("LeftShoulder", "RightShoulder"), ("LeftUpLeg", "RightUpLeg")):
+        left_index = joint_by_name.get(left_name)
+        right_index = joint_by_name.get(right_name)
+        if left_index is None or right_index is None:
+            continue
+        left = globals_[skin.joints[left_index]][:3, 3]
+        right = globals_[skin.joints[right_index]][:3, 3]
+        side = _projected_unit(right - left, GLTF_UP)
+        if side is None:
+            continue
+        forward = _safe_unit(np.cross(GLTF_UP, side))
+        if forward is not None:
+            return forward
+    return None
+
+
+def _frame_pivot(frame: FrameGeometry, joint_by_name: dict[str, int]) -> np.ndarray:
+    if frame.joints is not None:
+        hips = _joint_point(frame.joints, joint_by_name, "Hips")
+        if hips is not None:
+            return hips
+        return frame.joints.mean(axis=0)
+    return np.vstack(frame.vertices_by_primitive).mean(axis=0)
+
+
+def _apply_root_yaw_stabilization(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+) -> dict[str, Any]:
+    reference_yaw: float | None = None
+    yaw_deltas: list[float] = []
+    for frame in frames:
+        if frame.joints is None:
+            continue
+        yaw = _root_yaw_from_joints(frame.joints.copy(), joint_by_name)
+        if yaw is None:
+            continue
+        reference_yaw = yaw
+        break
+
+    if reference_yaw is None:
+        return {"enabled": True, "frames_adjusted": 0, "reason": "missing hip/leg joints"}
+
+    for frame in frames:
+        if frame.joints is None:
+            continue
+        yaw = _root_yaw_from_joints(frame.joints.copy(), joint_by_name)
+        if yaw is None:
+            yaw_deltas.append(0.0)
+            continue
+        delta = _wrap_angle(yaw - reference_yaw)
+        yaw_deltas.append(delta)
+        if abs(delta) > 1e-6:
+            _rotate_frame_y(frame, delta, _frame_pivot(frame, joint_by_name))
+
+    return {
+        "enabled": True,
+        "reference_yaw_degrees": float(np.degrees(reference_yaw)),
+        "frames_adjusted": int(sum(abs(delta) > 1e-6 for delta in yaw_deltas)),
+        "max_yaw_delta_degrees": float(np.degrees(max((abs(delta) for delta in yaw_deltas), default=0.0))),
+    }
+
+
+def _foot_points(
+    joints: np.ndarray,
+    joint_by_name: dict[str, int],
+    side: str,
+) -> tuple[np.ndarray | None, float | None]:
+    indices = [
+        joint_by_name[name]
+        for name in (f"{side}Foot", f"{side}ToeBase")
+        if name in joint_by_name
+    ]
+    if not indices:
+        return None, None
+    points = joints[indices]
+    return points.mean(axis=0), float(points[:, 1].min())
+
+
+def _contiguous_segments(mask: np.ndarray) -> list[tuple[int, int]]:
+    segments: list[tuple[int, int]] = []
+    start: int | None = None
+    for index, value in enumerate(mask):
+        if value and start is None:
+            start = index
+        elif not value and start is not None:
+            segments.append((start, index - 1))
+            start = None
+    if start is not None:
+        segments.append((start, len(mask) - 1))
+    return segments
+
+
+def _edge_blend_weight(index: int, start: int, end: int, frame_count: int, blend_frames: int) -> float:
+    if blend_frames <= 0:
+        return 1.0
+    weight = 1.0
+    if start > 0:
+        weight = min(weight, (index - start + 1) / (blend_frames + 1))
+    if end < frame_count - 1:
+        weight = min(weight, (end - index + 1) / (blend_frames + 1))
+    return float(np.clip(weight, 0.0, 1.0))
+
+
+def _blend_rotation(source: Rotation, target: Rotation, weight: float) -> Rotation:
+    weight = float(np.clip(weight, 0.0, 1.0))
+    if weight <= 0.0:
+        return source
+    if weight >= 1.0:
+        return target
+    delta = target * source.inv()
+    return Rotation.from_rotvec(delta.as_rotvec() * weight) * source
+
+
+def _source_foot_contact_mask(foot_contacts: np.ndarray | None, frame_count: int) -> np.ndarray | None:
+    if foot_contacts is None or len(foot_contacts) != frame_count:
+        return None
+    if foot_contacts.ndim != 2 or foot_contacts.shape[1] < 2:
+        return None
+    contacts = foot_contacts.astype(bool)
+    left = contacts[:, : min(2, contacts.shape[1])].any(axis=1)
+    if contacts.shape[1] >= 4:
+        right = contacts[:, 2:4].any(axis=1)
+    else:
+        right = contacts[:, -1]
+    return np.column_stack([left, right])
+
+
+def _select_lock_segments(support_mask: np.ndarray) -> list[tuple[int, int]]:
+    frame_count = len(support_mask)
+    segments = _contiguous_segments(support_mask)
+    selected: list[tuple[int, int]] = []
+    start_window_end = max(1, frame_count // 5)
+    landing_window_start = max(0, int(frame_count * 0.55))
+    for start, end in segments:
+        if start <= start_window_end or end >= landing_window_start:
+            selected.append((start, end))
+    landing_indices = [index for index, (start, end) in enumerate(selected) if end >= landing_window_start]
+    if landing_indices:
+        index = landing_indices[-1]
+        start, end = selected[index]
+        if start >= landing_window_start and end < frame_count - 1:
+            selected[index] = (start, frame_count - 1)
+    else:
+        lock_frames = max(3, min(8, frame_count // 5))
+        selected.append((frame_count - lock_frames, frame_count - 1))
+    return selected
+
+
+def _foot_contact_analysis(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    *,
+    ground_y: float,
+    contact_height: float,
+    contact_velocity: float | None = None,
+    source_foot_contacts: np.ndarray | None = None,
+    use_source_contacts: bool = True,
+) -> FootContactAnalysis | None:
+    frame_count = len(frames)
+    centers = np.full((frame_count, 2, 3), np.nan, dtype=np.float64)
+    lows = np.full((frame_count, 2), np.nan, dtype=np.float64)
+    for frame_index, frame in enumerate(frames):
+        if frame.joints is None:
+            continue
+        for side_index, side in enumerate(("Left", "Right")):
+            center, low = _foot_points(frame.joints, joint_by_name, side)
+            if center is not None and low is not None:
+                centers[frame_index, side_index] = center
+                lows[frame_index, side_index] = low
+
+    if np.isnan(lows).all():
+        return None
+
+    speeds = np.full((frame_count, 2), np.nan, dtype=np.float64)
+    for side_index in range(2):
+        valid = np.isfinite(centers[:, side_index]).all(axis=1)
+        side_speeds = np.full(frame_count, np.nan, dtype=np.float64)
+        if frame_count == 1:
+            side_speeds[valid] = 0.0
+        elif valid.any():
+            pair_valid = valid[:-1] & valid[1:]
+            diffs = np.full(frame_count - 1, np.nan, dtype=np.float64)
+            if pair_valid.any():
+                horizontal = centers[:, side_index, [0, 2]]
+                diffs[pair_valid] = np.linalg.norm(np.diff(horizontal, axis=0)[pair_valid], axis=1)
+            for frame_index in range(frame_count):
+                neighbors = []
+                if frame_index > 0 and np.isfinite(diffs[frame_index - 1]):
+                    neighbors.append(float(diffs[frame_index - 1]))
+                if frame_index < frame_count - 1 and np.isfinite(diffs[frame_index]):
+                    neighbors.append(float(diffs[frame_index]))
+                if neighbors:
+                    side_speeds[frame_index] = min(neighbors)
+        speeds[:, side_index] = side_speeds
+
+    height_mask = np.isfinite(lows) & (lows <= (ground_y + contact_height))
+    if contact_velocity is not None and contact_velocity > 0.0:
+        speed_mask = np.isfinite(speeds) & (speeds <= contact_velocity)
+    else:
+        speed_mask = np.isfinite(lows)
+    contact_mask = height_mask & speed_mask
+
+    source_contacts_used = False
+    source_contact_ratio = [0.0, 0.0]
+    source_mask = _source_foot_contact_mask(source_foot_contacts, frame_count) if use_source_contacts else None
+    if source_mask is not None:
+        ratios = source_mask.mean(axis=0)
+        source_contact_ratio = [float(ratios[0]), float(ratios[1])]
+        usable = (ratios >= 0.03) & (ratios <= 0.75)
+        if usable.any():
+            source_contacts_used = True
+            source_height_mask = np.isfinite(lows) & (lows <= ground_y + contact_height * 1.25)
+            if contact_velocity is not None and contact_velocity > 0.0:
+                source_speed_mask = np.isfinite(speeds) & (speeds <= contact_velocity * 1.75)
+            else:
+                source_speed_mask = np.isfinite(lows)
+            contact_mask = contact_mask | (
+                source_mask
+                & usable.reshape(1, 2)
+                & source_height_mask
+                & source_speed_mask
+            )
+    contact_mask = np.nan_to_num(contact_mask, nan=False).astype(bool)
+    support_mask = contact_mask.any(axis=1)
+    return FootContactAnalysis(
+        centers=centers,
+        lows=lows,
+        speeds=speeds,
+        contact_mask=contact_mask,
+        segments=[
+            (start, end)
+            for start, end in _contiguous_segments(support_mask)
+            if end - start + 1 >= 2
+        ],
+        source_contacts_used=source_contacts_used,
+        source_contact_ratio=source_contact_ratio,
+    )
+
+
+def _smooth_unit_vectors(vectors: np.ndarray, valid: np.ndarray, *, radius: int = 2) -> np.ndarray:
+    smoothed = vectors.copy()
+    for index in range(len(vectors)):
+        if not valid[index]:
+            continue
+        start = max(0, index - radius)
+        end = min(len(vectors), index + radius + 1)
+        window = vectors[start:end][valid[start:end]]
+        if len(window) == 0:
+            continue
+        average = _safe_unit(window.mean(axis=0))
+        if average is not None:
+            smoothed[index] = average
+    return smoothed
+
+
+def _canonical_airborne_leg_direction(side: str, tuck: float) -> np.ndarray:
+    side_offset = -0.08 if side == "Left" else 0.08
+    extended = np.array([side_offset, -0.98, 0.08], dtype=np.float64)
+    tucked = np.array([side_offset, -0.20, 0.98], dtype=np.float64)
+    blended = extended * (1.0 - tuck) + tucked * tuck
+    direction = _safe_unit(blended)
+    return direction if direction is not None else tucked
+
+
+def _airborne_leg_guides(
+    *,
+    clip: MotionClip,
+    rough_frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    options: RetargetOptions,
+) -> tuple[list[dict[str, AirborneLegGuide] | None], dict[str, Any]]:
+    frame_count = len(rough_frames)
+    guides: list[dict[str, AirborneLegGuide] | None] = [None for _ in range(frame_count)]
+    if clip.posed_joints is None:
+        return guides, {"enabled": True, "guided_frames": 0, "reason": "missing posed joints"}
+
+    analysis = _foot_contact_analysis(
+        rough_frames,
+        joint_by_name,
+        ground_y=options.ground_y,
+        contact_height=options.foot_contact_height,
+        contact_velocity=options.foot_contact_velocity,
+        source_foot_contacts=None,
+        use_source_contacts=False,
+    )
+    if analysis is None:
+        return guides, {"enabled": True, "guided_frames": 0, "reason": "missing foot joints"}
+
+    support_mask = analysis.contact_mask.any(axis=1)
+    air_segments = [
+        (start, end)
+        for start, end in _contiguous_segments(~support_mask)
+        if end - start + 1 >= 3
+    ]
+    if not air_segments:
+        return guides, {"enabled": True, "guided_frames": 0, "segments": []}
+
+    local_dirs = {side: np.zeros((frame_count, 3), dtype=np.float64) for side in ("Left", "Right")}
+    reach_ratios = {side: np.ones(frame_count, dtype=np.float64) for side in ("Left", "Right")}
+    valid = {side: np.zeros(frame_count, dtype=bool) for side in ("Left", "Right")}
+
+    for frame_index in range(frame_count):
+        source = _source_to_avatar_axes(clip.posed_joints[frame_index].astype(np.float64))
+        basis = _source_body_basis(source)
+        if basis is None:
+            continue
+        for side in ("Left", "Right"):
+            source_map = SMPL_LEG_JOINTS[side]
+            hip = source[source_map["hip"]]
+            knee = source[source_map["knee"]]
+            ankle = source[source_map["ankle"]]
+            direction = _safe_unit(ankle - hip)
+            upper = float(np.linalg.norm(knee - hip))
+            lower = float(np.linalg.norm(ankle - knee))
+            chain = upper + lower
+            if direction is None or chain < 1e-8:
+                continue
+            local_direction = _safe_unit(basis.T @ direction)
+            if local_direction is None:
+                continue
+            local_dirs[side][frame_index] = local_direction
+            reach_ratios[side][frame_index] = float(np.linalg.norm(ankle - hip) / chain)
+            valid[side][frame_index] = True
+
+    smoothed_dirs = {
+        side: _smooth_unit_vectors(local_dirs[side], valid[side], radius=2)
+        for side in ("Left", "Right")
+    }
+    strength = float(np.clip(options.airborne_leg_stabilization_strength, 0.0, 1.0))
+    guided_frames: set[int] = set()
+    segment_records: list[dict[str, int]] = []
+
+    for start, end in air_segments:
+        span = max(1, end - start)
+        segment_records.append({"start": int(start), "end": int(end)})
+        for frame_index in range(start, end + 1):
+            phase = (frame_index - start) / span
+            tuck = float(np.sin(np.pi * phase))
+            blend = strength * (0.35 + 0.65 * tuck)
+            blend *= _edge_blend_weight(
+                frame_index,
+                start,
+                end,
+                frame_count,
+                options.foot_lock_blend_frames,
+            )
+            if blend <= 0.0:
+                continue
+            frame_guides: dict[str, AirborneLegGuide] = {}
+            for side in ("Left", "Right"):
+                if not valid[side][frame_index]:
+                    continue
+                canonical_direction = _canonical_airborne_leg_direction(side, tuck)
+                direction = _safe_unit(
+                    smoothed_dirs[side][frame_index] * (1.0 - blend)
+                    + canonical_direction * blend
+                )
+                if direction is None:
+                    continue
+                canonical_reach = (1.0 - tuck) * 0.96 + tuck * options.airborne_tuck_reach_ratio
+                reach_ratio = float(
+                    reach_ratios[side][frame_index] * (1.0 - blend) + canonical_reach * blend
+                )
+                frame_guides[side] = AirborneLegGuide(
+                    direction_local=direction,
+                    reach_ratio=reach_ratio,
+                )
+            if frame_guides:
+                guides[frame_index] = frame_guides
+                guided_frames.add(frame_index)
+
+    return guides, {
+        "enabled": True,
+        "guided_frames": len(guided_frames),
+        "segments": segment_records,
+        "strength": strength,
+        "tuck_reach_ratio": options.airborne_tuck_reach_ratio,
+        "strategy": (
+            "smooth airborne leg directions in source pelvis-local space and blend them toward "
+            "a symmetric backflip tuck curve before target-rig two-bone IK"
+        ),
+    }
+
+
+def _apply_foot_contact_lock(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    *,
+    ground_y: float,
+    contact_height: float,
+    blend_frames: int,
+    contact_velocity: float | None = None,
+    source_foot_contacts: np.ndarray | None = None,
+    use_source_contacts: bool = True,
+) -> dict[str, Any]:
+    frame_count = len(frames)
+    analysis = _foot_contact_analysis(
+        frames,
+        joint_by_name,
+        ground_y=ground_y,
+        contact_height=contact_height,
+        contact_velocity=contact_velocity,
+        source_foot_contacts=source_foot_contacts,
+        use_source_contacts=use_source_contacts,
+    )
+    if analysis is None:
+        return {"enabled": True, "locked_frames": 0, "reason": "missing foot joints"}
+
+    centers = analysis.centers
+    lows = analysis.lows
+    contact_mask = analysis.contact_mask
+    segments = analysis.segments
+
+    locked_frames: set[int] = set()
+    applied_segments: list[dict[str, Any]] = []
+    frame_deltas: list[list[np.ndarray]] = [[] for _ in range(frame_count)]
+    sides = ("Left", "Right")
+    for side_index, side in enumerate(sides):
+        side_segments = [
+            (start, end)
+            for start, end in _contiguous_segments(contact_mask[:, side_index])
+            if end - start + 1 >= 2
+        ]
+        for start, end in side_segments:
+            side_centers = centers[start : end + 1, side_index]
+            side_lows = lows[start : end + 1, side_index]
+            side_speeds = analysis.speeds[start : end + 1, side_index]
+            valid = np.isfinite(side_centers).all(axis=1) & np.isfinite(side_lows)
+            if not valid.any():
+                continue
+            anchor_xy = np.nanmedian(side_centers[valid][:, [0, 2]], axis=0)
+            score = np.abs(side_lows - ground_y)
+            if np.isfinite(side_speeds).any():
+                score = score + np.nan_to_num(side_speeds, nan=np.nanmax(side_speeds[np.isfinite(side_speeds)])) * 8.0
+            score[~valid] = np.inf
+            anchor_frame = int(start + np.argmin(score))
+            applied_segments.append(
+                {
+                    "start": int(start),
+                    "end": int(end),
+                    "anchor_frame": anchor_frame,
+                    "side": side,
+                }
+            )
+            for frame_index in range(start, end + 1):
+                current = centers[frame_index, side_index]
+                low = lows[frame_index, side_index]
+                if np.isnan(current).any() or np.isnan(low):
+                    continue
+                weight = _edge_blend_weight(frame_index, start, end, frame_count, blend_frames)
+                if weight <= 0.0:
+                    continue
+                delta = np.array(
+                    [
+                        anchor_xy[0] - current[0],
+                        ground_y - low,
+                        anchor_xy[1] - current[2],
+                    ],
+                    dtype=np.float64,
+                )
+                frame_deltas[frame_index].append(delta * weight)
+
+    for frame_index, deltas in enumerate(frame_deltas):
+        if not deltas:
+            continue
+        _translate_frame(frames[frame_index], np.mean(deltas, axis=0))
+        locked_frames.add(frame_index)
+
+    ground_lifts = 0
+    for frame in frames:
+        lowest = min(float(vertices[:, 1].min()) for vertices in frame.vertices_by_primitive)
+        if lowest < ground_y:
+            _translate_frame(frame, np.array([0.0, ground_y - lowest, 0.0], dtype=np.float64))
+            ground_lifts += 1
+
+    return {
+        "enabled": True,
+        "locked_frames": len(locked_frames),
+        "segments": applied_segments,
+        "ground_lift_frames": ground_lifts,
+        "contact_height": contact_height,
+        "contact_velocity": contact_velocity,
+        "contact_frames_by_side": {
+            "Left": int(contact_mask[:, 0].sum()),
+            "Right": int(contact_mask[:, 1].sum()),
+        },
+        "source_contacts_used": analysis.source_contacts_used,
+        "source_contact_ratio": analysis.source_contact_ratio,
+        "strategy": "per-foot height+horizontal-speed contact locking",
+        "blend_frames": blend_frames,
+    }
+
+
+def _apply_contact_foot_orientation_lock(
+    *,
+    local_quats_by_frame: list[np.ndarray],
+    rough_frames: list[FrameGeometry],
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    calibrations: list[LegCalibration],
+    clip: MotionClip,
+    options: RetargetOptions,
+) -> dict[str, Any]:
+    if not calibrations:
+        return {"enabled": True, "locked_frames": 0, "reason": "missing leg calibration"}
+
+    analysis = _foot_contact_analysis(
+        rough_frames,
+        joint_by_name,
+        ground_y=options.ground_y,
+        contact_height=options.foot_contact_height,
+        contact_velocity=options.foot_contact_velocity,
+        source_foot_contacts=clip.foot_contacts,
+        use_source_contacts=options.foot_contact_use_source,
+    )
+    if analysis is None:
+        return {"enabled": True, "locked_frames": 0, "reason": "missing foot joints"}
+
+    skin = gltf.skins[0]
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
+    }
+    calibration_by_side = {calibration.side: calibration for calibration in calibrations}
+    reference_globals = node_global_matrices(gltf, local_quats_by_frame[0])
+    reference_forward = _body_forward_from_globals(reference_globals, gltf, skin, joint_by_name)
+
+    reference_yaw: float | None = None
+    if options.stabilize_root_yaw:
+        for frame in rough_frames:
+            if frame.joints is None:
+                continue
+            yaw = _root_yaw_from_joints(frame.joints.copy(), joint_by_name)
+            if yaw is not None:
+                reference_yaw = yaw
+                break
+
+    frame_count = len(local_quats_by_frame)
+    locked_frames: set[int] = set()
+    applied_segments: list[dict[str, Any]] = []
+
+    for start, end in analysis.segments:
+        if start > end:
+            continue
+        segment_mask = analysis.contact_mask[start : end + 1]
+        side_indices = [index for index in range(2) if segment_mask[:, index].any()]
+        if not side_indices:
+            continue
+
+        applied_segments.append(
+            {
+                "start": int(start),
+                "end": int(end),
+                "sides": ["Left" if index == 0 else "Right" for index in side_indices],
+            }
+        )
+        for frame_index in range(start, end + 1):
+            weight = _edge_blend_weight(frame_index, start, end, frame_count, options.foot_lock_blend_frames)
+            if weight <= 0.0:
+                continue
+            globals_ = node_global_matrices(gltf, local_quats_by_frame[frame_index])
+            for side_index in side_indices:
+                if not analysis.contact_mask[frame_index, side_index]:
+                    continue
+                side = "Left" if side_index == 0 else "Right"
+                calibration = calibration_by_side.get(side)
+                if (
+                    calibration is None
+                    or calibration.rest_toe_local is None
+                    or calibration.rest_foot_up_local is None
+                ):
+                    continue
+
+                parent_rotation = _rotation_from_matrix(globals_[skin.joints[calibration.knee]])
+                desired_toe_direction = reference_forward if reference_forward is not None else calibration.rest_contact_toe_global
+                if desired_toe_direction is None:
+                    continue
+                if reference_yaw is not None and rough_frames[frame_index].joints is not None:
+                    yaw = _root_yaw_from_joints(rough_frames[frame_index].joints.copy(), joint_by_name)
+                    if yaw is not None:
+                        yaw_delta = _wrap_angle(yaw - reference_yaw)
+                        desired_toe_direction = Rotation.from_rotvec(GLTF_UP * yaw_delta).apply(
+                            desired_toe_direction
+                        )
+                desired_foot_rotation = _basis_rotation(
+                    calibration.rest_toe_local,
+                    calibration.rest_foot_up_local,
+                    desired_toe_direction,
+                    GLTF_UP,
+                )
+                target_delta = local_rest_rot[calibration.ankle].inv() * parent_rotation.inv() * desired_foot_rotation
+                current_delta = Rotation.from_quat(local_quats_by_frame[frame_index][calibration.ankle])
+                local_quats_by_frame[frame_index][calibration.ankle] = _blend_rotation(
+                    current_delta,
+                    target_delta,
+                    weight,
+                ).as_quat()
+                if calibration.toe is not None:
+                    current_toe_delta = Rotation.from_quat(local_quats_by_frame[frame_index][calibration.toe])
+                    local_quats_by_frame[frame_index][calibration.toe] = _blend_rotation(
+                        current_toe_delta,
+                        Rotation.identity(),
+                        weight,
+                    ).as_quat()
+                locked_frames.add(frame_index)
+
+    return {
+        "enabled": True,
+        "locked_frames": len(locked_frames),
+        "segments": applied_segments,
+        "contact_height": options.foot_contact_height,
+        "contact_velocity": options.foot_contact_velocity,
+        "source_contacts_used": analysis.source_contacts_used,
+        "source_contact_ratio": analysis.source_contact_ratio,
+        "strategy": (
+            "align contact foot toe vector to the target rig body-facing direction, "
+            "align foot up to ground normal, and neutralize toe-base curl"
+        ),
+        "blend_frames": options.foot_lock_blend_frames,
+    }
+
+
+def _postprocess_frames(
+    frames: list[FrameGeometry],
+    joint_by_name: dict[str, int],
+    clip: MotionClip,
+    options: RetargetOptions,
+) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "root_yaw_stabilization": {"enabled": False},
+        "foot_contact_lock": {"enabled": False},
+        "foot_orientation_lock": {"enabled": False},
+    }
+    if options.stabilize_root_yaw:
+        report["root_yaw_stabilization"] = _apply_root_yaw_stabilization(frames, joint_by_name)
+    if options.foot_contact_lock:
+        report["foot_contact_lock"] = _apply_foot_contact_lock(
+            frames,
+            joint_by_name,
+            ground_y=options.ground_y,
+            contact_height=options.foot_contact_height,
+            contact_velocity=options.foot_contact_velocity,
+            blend_frames=options.foot_lock_blend_frames,
+            source_foot_contacts=clip.foot_contacts,
+            use_source_contacts=options.foot_contact_use_source,
+        )
+    return report
+
+
+def _boundary_edges(faces: np.ndarray) -> np.ndarray:
+    edges = np.vstack([faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [2, 0]]])
+    sorted_edges = np.sort(edges, axis=1)
+    unique, counts = np.unique(sorted_edges, axis=0, return_counts=True)
+    return unique[counts == 1]
+
+
+def _is_hair_primitive(source: Any) -> bool:
+    names = [str(source.metadata.get("name", "")) if hasattr(source, "metadata") else ""]
+    material = getattr(getattr(source, "visual", None), "material", None)
+    if material is not None:
+        names.append(str(getattr(material, "name", "") or ""))
+    return "hair" in " ".join(names).lower()
+
+
+def _solidified_visual(source: Any, vertex_count: int) -> Any:
+    visual = source.visual.copy()
+    if hasattr(source.visual, "uv") and source.visual.uv is not None:
+        uv = np.asarray(source.visual.uv)
+        if len(uv) == vertex_count:
+            return trimesh.visual.TextureVisuals(
+                uv=np.vstack([uv, uv]),
+                material=source.visual.material,
+            )
+    return visual
+
+
+def _solidify_vertices(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    source: Any,
+    *,
+    thickness: float,
+) -> tuple[np.ndarray, np.ndarray, Any]:
+    if thickness <= 0:
+        return vertices, faces, source.visual.copy()
+
+    mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+    normals = np.asarray(mesh.vertex_normals, dtype=np.float64).copy()
+    normals /= np.linalg.norm(normals, axis=1, keepdims=True) + 1e-9
+
+    outer = vertices + normals * (thickness * 0.5)
+    inner = vertices - normals * (thickness * 0.5)
+    solid_vertices = np.vstack([outer, inner])
+    inner_offset = len(vertices)
+
+    face_sets = [faces, faces[:, ::-1] + inner_offset]
+    side_faces = []
+    for a, b in _boundary_edges(faces):
+        side_faces.append([a, b, b + inner_offset])
+        side_faces.append([a, b + inner_offset, a + inner_offset])
+    if side_faces:
+        face_sets.append(np.asarray(side_faces, dtype=np.int64))
+
+    solid_faces = np.vstack(face_sets)
+    return solid_vertices, solid_faces, _solidified_visual(source, len(vertices))
+
+
+def _export_frame(
+    glb_path: Path,
+    vertices_by_primitive: list[np.ndarray],
+    source_geometries: list[Any],
+    *,
+    options: RetargetOptions,
+) -> None:
+    scene = trimesh.Scene()
+    for primitive_index, vertices in enumerate(vertices_by_primitive):
+        if primitive_index >= len(source_geometries):
+            raise ValueError(
+                f"deformed primitive count exceeds source geometry count: {primitive_index + 1}>{len(source_geometries)}"
+            )
+        source = source_geometries[primitive_index]
+        faces = source.faces.copy()
+        thickness = (
+            options.hair_shell_thickness if _is_hair_primitive(source) else options.body_shell_thickness
+        )
+        if not options.solidify_shell:
+            thickness = 0.0
+        solid_vertices, solid_faces, visual = _solidify_vertices(
+            vertices,
+            faces,
+            source,
+            thickness=thickness,
+        )
+        mesh = trimesh.Trimesh(vertices=solid_vertices, faces=solid_faces, process=False)
+        mesh.visual = visual
+        name = source.metadata.get("name", "primitive") if hasattr(source, "metadata") else "primitive"
+        scene.add_geometry(mesh, geom_name=f"{name}_{primitive_index:02d}")
+    scene.export(glb_path, include_normals=True)
+
+
+def _build_frame_geometries(
+    *,
+    gltf: GLTF2,
+    skin: Any,
+    local_quats_by_frame: list[np.ndarray],
+    normalizer: VertexNormalizer,
+    clip: MotionClip,
+    options: RetargetOptions,
+) -> list[FrameGeometry]:
+    frames: list[FrameGeometry] = []
+    for frame_index, local_quats in enumerate(local_quats_by_frame):
+        deformed = deform_skinned_primitives(gltf, local_quats)
+        globals_ = node_global_matrices(gltf, local_quats)
+        joint_points = np.stack([globals_[joint][:3, 3] for joint in skin.joints])
+        transformed, transformed_joints = normalizer.transform(
+            deformed,
+            joint_points,
+            root_offset=_root_offset(clip, frame_index, options=options, normalizer=normalizer),
+            snap_to_ground=options.snap_to_ground,
+        )
+        frames.append(FrameGeometry(vertices_by_primitive=transformed, joints=transformed_joints))
+    return frames
+
+
+def retarget_motion_to_avatar(
+    *,
+    avatar_glb: Path,
+    motion: MotionClip,
+    output_dir: Path,
+    asset_name: str,
+    prompt: str,
+    identity: str,
+    options: RetargetOptions | None = None,
+    selection: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    options = options or RetargetOptions()
+    clip = resample_motion(motion, options.frames)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    gltf = GLTF2().load(str(avatar_glb))
+    if not gltf.skins:
+        raise ValueError(f"avatar GLB has no skin: {avatar_glb}")
+    skin = gltf.skins[0]
+    joint_by_name = {joint_base_name(gltf.nodes[joint].name): index for index, joint in enumerate(skin.joints)}
+    source_geometries = _source_geometries(avatar_glb)
+    rest_joint_deltas = identity_quaternions(len(skin.joints))
+    rest_globals = node_global_matrices(gltf, rest_joint_deltas)
+    leg_calibrations = _leg_calibrations(gltf, joint_by_name, rest_globals)
+    leg_ik_enabled = options.calibrated_leg_ik and clip.posed_joints is not None and bool(leg_calibrations)
+
+    rest_vertices = deform_skinned_primitives(gltf, rest_joint_deltas)
+    normalizer = VertexNormalizer.from_vertices(
+        rest_vertices, target_height=options.target_height, ground_y=options.ground_y
+    )
+
+    material_changes: dict[str, Any] = {}
+    bounds: list[dict[str, list[float]]] = []
+    joint_names = [joint_base_name(gltf.nodes[joint].name) for joint in skin.joints]
+
+    def build_local_quats_by_frame(
+        leg_guides: list[dict[str, AirborneLegGuide] | None] | None = None,
+    ) -> list[np.ndarray]:
+        quats_by_frame: list[np.ndarray] = []
+        for frame_index in range(options.frames):
+            if options.prefer_joint_position_ik and clip.posed_joints is not None:
+                local_quats = _ik_local_quats_for_frame(clip.posed_joints[frame_index], gltf, joint_by_name)
+            else:
+                local_quats = _local_quats_for_frame(
+                    clip.local_rot_mats[frame_index], joint_by_name, options=options
+                )
+                if leg_ik_enabled:
+                    local_quats = _apply_calibrated_leg_ik(
+                        local=local_quats,
+                        source_joints=clip.posed_joints[frame_index],
+                        source_global_rot_mats=clip.global_rot_mats[frame_index]
+                        if clip.global_rot_mats is not None
+                        else None,
+                        gltf=gltf,
+                        joint_by_name=joint_by_name,
+                        calibrations=leg_calibrations,
+                        body_relative=options.body_relative_leg_ik,
+                        leg_guide=leg_guides[frame_index] if leg_guides is not None else None,
+                    )
+            quats_by_frame.append(local_quats)
+        return quats_by_frame
+
+    local_quats_by_frame = build_local_quats_by_frame()
+
+    pre_postprocess: dict[str, Any] = {
+        "airborne_leg_stabilization": {"enabled": False},
+        "foot_orientation_lock": {"enabled": False},
+    }
+    if options.airborne_leg_stabilization and leg_ik_enabled:
+        rough_frames = _build_frame_geometries(
+            gltf=gltf,
+            skin=skin,
+            local_quats_by_frame=local_quats_by_frame,
+            normalizer=normalizer,
+            clip=clip,
+            options=options,
+        )
+        leg_guides, air_report = _airborne_leg_guides(
+            clip=clip,
+            rough_frames=rough_frames,
+            joint_by_name=joint_by_name,
+            options=options,
+        )
+        pre_postprocess["airborne_leg_stabilization"] = air_report
+        if air_report.get("guided_frames", 0) > 0:
+            local_quats_by_frame = build_local_quats_by_frame(leg_guides)
+
+    if options.foot_contact_lock and options.foot_orientation_lock:
+        rough_frames = _build_frame_geometries(
+            gltf=gltf,
+            skin=skin,
+            local_quats_by_frame=local_quats_by_frame,
+            normalizer=normalizer,
+            clip=clip,
+            options=options,
+        )
+        pre_postprocess["foot_orientation_lock"] = _apply_contact_foot_orientation_lock(
+            local_quats_by_frame=local_quats_by_frame,
+            rough_frames=rough_frames,
+            gltf=gltf,
+            joint_by_name=joint_by_name,
+            calibrations=leg_calibrations,
+            clip=clip,
+            options=options,
+        )
+
+    frame_geometries = _build_frame_geometries(
+        gltf=gltf,
+        skin=skin,
+        local_quats_by_frame=local_quats_by_frame,
+        normalizer=normalizer,
+        clip=clip,
+        options=options,
+    )
+    postprocess = _postprocess_frames(frame_geometries, joint_by_name, clip, options)
+    postprocess = {**postprocess, **pre_postprocess}
+    skeleton_frames = [
+        frame.joints.tolist()
+        for frame in frame_geometries
+        if frame.joints is not None
+    ]
+
+    for frame_index, frame in enumerate(frame_geometries):
+        glb_path = output_dir / f"frame{frame_index:03d}.glb"
+        _export_frame(glb_path, frame.vertices_by_primitive, source_geometries, options=options)
+        material_changes[glb_path.name] = fix_habitat_materials(
+            glb_path,
+            alpha_cutoff=options.alpha_cutoff,
+            roughness=options.material_roughness,
+            detect_texture_alpha=options.detect_texture_alpha,
+        )
+        write_object_config(output_dir / f"frame{frame_index:03d}.object_config.json", glb_path)
+
+        combined = np.vstack(frame.vertices_by_primitive)
+        bounds.append({"min": combined.min(axis=0).tolist(), "max": combined.max(axis=0).tolist()})
+
+    skeleton = {
+        "joint_names": joint_names,
+        "frames": skeleton_frames,
+        "fps": options.fps,
+        "source_skeleton": "SMPL-22/Kimodo local rotations retargeted to avatar skin joints",
+        "leg_ik": {
+            "enabled": leg_ik_enabled,
+            "strategy": (
+                "body-relative calibrated two-bone IK with target-rig knee pole constraints"
+                if options.body_relative_leg_ik
+                else "calibrated two-bone IK with target-rig knee pole constraints"
+            ),
+            "legs": [calibration.side for calibration in leg_calibrations],
+            "body_relative": options.body_relative_leg_ik,
+        },
+        "postprocess": postprocess,
+    }
+    (output_dir / "skeleton.json").write_text(json.dumps(skeleton, indent=2), encoding="utf-8")
+
+    persona = {
+        "asset_name": asset_name,
+        "identity": identity,
+        "prompt": prompt,
+        "avatar_glb": str(avatar_glb),
+        "motion_source": str(motion.source_path),
+        "frames": options.frames,
+        "fps": options.fps,
+        "appearance_strategy": "preserve original ViCo/Mixamo skinned GLB mesh, UVs, skin weights, and textures",
+        "retarget_strategy": (
+            "map SMPL-22/GEM/Kimodo local rotations to compatible ViCo/Mixamo skin joints; "
+            "when posed joints are available, solve calibrated two-bone leg IK using the target rig knee pole; "
+            "body-relative leg mapping and airborne leg stabilization are experimental opt-in modes; "
+            "optionally stabilize root yaw and lock support feet during contact/landing"
+        ),
+        "selection": selection or {},
+        "material_strategy": {
+            "hair_and_alpha_materials": "MASK",
+            "double_sided": True,
+            "roughness_min": options.material_roughness,
+            "solidify_shell": options.solidify_shell,
+            "body_shell_thickness_m": options.body_shell_thickness,
+            "hair_shell_thickness_m": options.hair_shell_thickness,
+        },
+        "postprocess": postprocess,
+    }
+    (output_dir / "persona.json").write_text(json.dumps(persona, indent=2), encoding="utf-8")
+    (output_dir / "habitat_material_fix_report.json").write_text(
+        json.dumps({"material_changes": material_changes}, indent=2), encoding="utf-8"
+    )
+
+    report = {
+        "asset_name": asset_name,
+        "asset_dir": str(output_dir),
+        "avatar_glb": str(avatar_glb),
+        "motion_source": str(motion.source_path),
+        "prompt": prompt,
+        "frames": options.frames,
+        "glb_count": len(list(output_dir.glob("frame*.glb"))),
+        "object_config_count": len(list(output_dir.glob("frame*.object_config.json"))),
+        "skeleton": str(output_dir / "skeleton.json"),
+        "bounds": bounds,
+        "min_ground_y": min(item["min"][1] for item in bounds),
+        "max_top_y": max(item["max"][1] for item in bounds),
+        "max_height": max(item["max"][1] - item["min"][1] for item in bounds),
+        "leg_ik": skeleton["leg_ik"],
+        "postprocess": postprocess,
+    }
+    return report

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -559,7 +559,7 @@ def _apply_calibrated_leg_ik(
             for index in range(min(len(source_global_rot_mats), len(SMPL22_TO_MIXAMO)))
         }
     current_globals = node_global_matrices(gltf, local)
-    target_basis = _target_body_basis_from_globals(current_globals, skin, joint_by_name) if body_relative else None
+    target_basis = _target_body_basis_from_globals(current_globals, skin, joint_by_name)
     local_rest_rot = {
         skin_index: _local_rest_rotation(gltf, node_index) for skin_index, node_index in enumerate(skin.joints)
     }
@@ -643,7 +643,7 @@ def _apply_calibrated_leg_ik(
             (guide is None or not guide.skip_foot_ik)
             and calibration.toe is not None
             and calibration.rest_toe_local is not None
-            and calibration.rest_pole_foot_local is not None
+            and calibration.rest_foot_up_local is not None
         ):
             source_toe = source[source_map["toe"]]
             source_toe_direction = _source_body_relative_direction(
@@ -656,11 +656,18 @@ def _apply_calibrated_leg_ik(
             )
             if source_toe_direction is not None:
                 knee_global_rot = hip_global_rot * local_rest_rot[calibration.knee] * knee_delta
+                body_up_target = target_basis[:, 1] if target_basis is not None else GLTF_UP
+                up_minus_toe = body_up_target - source_toe_direction * float(
+                    np.dot(body_up_target, source_toe_direction)
+                )
+                foot_up_target = _safe_unit(up_minus_toe)
+                if foot_up_target is None:
+                    foot_up_target = body_up_target
                 desired_foot_rot = _basis_rotation(
                     calibration.rest_toe_local,
-                    calibration.rest_pole_foot_local,
+                    calibration.rest_foot_up_local,
                     source_toe_direction,
-                    pole,
+                    foot_up_target,
                 )
                 foot_delta = local_rest_rot[calibration.ankle].inv() * knee_global_rot.inv() * desired_foot_rot
                 local[calibration.ankle] = foot_delta.as_quat()

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -701,11 +701,13 @@ def _apply_calibrated_arm_ik(
         if source_chain_len < 1e-8:
             continue
 
-        source_direction = _source_body_relative_direction(
-            source_wrist - source_shoulder,
-            source_body_basis=source_basis,
-            target_body_basis=target_basis,
-        )
+        source_direction = None
+        if source_basis is not None and target_basis is not None:
+            local_direction = source_basis.T @ (source_wrist - source_shoulder)
+            local_direction[2] *= -1.0
+            source_direction = _safe_unit(target_basis @ local_direction)
+        if source_direction is None:
+            source_direction = _safe_unit(source_wrist - source_shoulder)
         if source_direction is None:
             continue
         reach_ratio = float(np.linalg.norm(source_wrist - source_shoulder) / source_chain_len)
@@ -719,7 +721,9 @@ def _apply_calibrated_arm_ik(
         source_pole = _limb_pole(source_shoulder, source_elbow, source_wrist)
         pole = None
         if source_basis is not None and target_basis is not None:
-            pole = _projected_unit(target_basis @ (source_basis.T @ source_pole), source_direction)
+            local_pole = source_basis.T @ source_pole
+            local_pole[2] *= -1.0
+            pole = _projected_unit(target_basis @ local_pole, source_direction)
         if pole is None:
             pole = _projected_unit(source_pole, source_direction)
         if pole is None:

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -106,7 +106,12 @@ class RetargetOptions:
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
     procedural_running_arm_swing: bool = True
-    running_arm_swing_strength: float = 0.88
+    running_arm_swing_strength: float = 0.35
+    running_arm_forward_ratio: float = 0.52
+    running_arm_drop_ratio: float = 0.50
+    running_arm_side_ratio: float = 0.055
+    running_arm_reach_min: float = 0.46
+    running_arm_reach_max: float = 0.68
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
     hair_shell_thickness: float = 0.006
@@ -1492,11 +1497,14 @@ def _apply_procedural_running_arm_swing(
             swing = float(np.clip(swing, -1.0, 1.0))
             shoulder = globals_[skin.joints[calibration.upper]][:3, 3]
             chain_len = calibration.upper_len + calibration.lower_len
+            forward_ratio = float(max(options.running_arm_forward_ratio, 0.0))
+            drop_ratio = float(max(options.running_arm_drop_ratio, 0.0))
+            side_ratio = float(max(options.running_arm_side_ratio, 0.0))
             hand_target = (
                 shoulder
-                + side_axis * side_sign * (0.11 * chain_len)
-                - up_axis * (0.72 * chain_len)
-                + forward_axis * (0.32 * chain_len * swing)
+                + side_axis * side_sign * (side_ratio * chain_len)
+                - up_axis * (drop_ratio * chain_len)
+                + forward_axis * (forward_ratio * chain_len * swing)
             )
             direction = _safe_unit(hand_target - shoulder)
             if direction is None:
@@ -1508,8 +1516,8 @@ def _apply_procedural_running_arm_swing(
             reach_ratio = float(
                 np.clip(
                     np.linalg.norm(hand_target - shoulder) / max(chain_len, 1e-8),
-                    0.56,
-                    0.86,
+                    options.running_arm_reach_min,
+                    options.running_arm_reach_max,
                 )
             )
             elbow, wrist = _two_bone_knee_position(
@@ -1576,6 +1584,13 @@ def _apply_procedural_running_arm_swing(
         "frames_adjusted": len(adjusted_frames),
         "channels_adjusted": adjusted_channels,
         "strength": strength,
+        "target": {
+            "forward_ratio": float(options.running_arm_forward_ratio),
+            "drop_ratio": float(options.running_arm_drop_ratio),
+            "side_ratio": float(options.running_arm_side_ratio),
+            "reach_min": float(options.running_arm_reach_min),
+            "reach_max": float(options.running_arm_reach_max),
+        },
         "phase": phase_report,
         "strategy": (
             "derive a reciprocal arm phase from Kimodo left/right ankle forward offsets, "

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -846,6 +846,55 @@ def _source_foot_contact_mask(foot_contacts: np.ndarray | None, frame_count: int
     return np.column_stack([left, right])
 
 
+def _fill_short_false_gaps(mask: np.ndarray, max_gap_frames: int) -> np.ndarray:
+    if max_gap_frames <= 0:
+        return mask
+    filled = mask.copy()
+    for start, end in _contiguous_segments(~filled):
+        if start == 0 or end == len(filled) - 1:
+            continue
+        if end - start + 1 <= max_gap_frames:
+            filled[start : end + 1] = True
+    return filled
+
+
+def _drop_short_true_segments(mask: np.ndarray, min_frames: int) -> np.ndarray:
+    if min_frames <= 1:
+        return mask
+    cleaned = mask.copy()
+    for start, end in _contiguous_segments(cleaned):
+        if end - start + 1 < min_frames:
+            cleaned[start : end + 1] = False
+    return cleaned
+
+
+def _stabilize_contact_mask(
+    enter_mask: np.ndarray,
+    stay_mask: np.ndarray,
+    *,
+    min_frames: int = 2,
+    max_gap_frames: int = 2,
+) -> np.ndarray:
+    stabilized = np.zeros_like(enter_mask, dtype=bool)
+    for side_index in range(enter_mask.shape[1]):
+        active = False
+        for frame_index in range(len(enter_mask)):
+            if active:
+                active = bool(stay_mask[frame_index, side_index])
+            else:
+                active = bool(enter_mask[frame_index, side_index])
+            stabilized[frame_index, side_index] = active
+        stabilized[:, side_index] = _fill_short_false_gaps(
+            stabilized[:, side_index],
+            max_gap_frames,
+        )
+        stabilized[:, side_index] = _drop_short_true_segments(
+            stabilized[:, side_index],
+            min_frames,
+        )
+    return stabilized
+
+
 def _select_lock_segments(support_mask: np.ndarray) -> list[tuple[int, int]]:
     frame_count = len(support_mask)
     segments = _contiguous_segments(support_mask)
@@ -915,11 +964,19 @@ def _foot_contact_analysis(
         speeds[:, side_index] = side_speeds
 
     height_mask = np.isfinite(lows) & (lows <= (ground_y + contact_height))
+    stay_height_mask = np.isfinite(lows) & (
+        lows <= ground_y + max(contact_height * 1.7, contact_height + 0.025)
+    )
     if contact_velocity is not None and contact_velocity > 0.0:
         speed_mask = np.isfinite(speeds) & (speeds <= contact_velocity)
+        stay_speed_mask = np.isfinite(speeds) & (
+            speeds <= max(contact_velocity * 2.25, contact_velocity + 0.015)
+        )
     else:
         speed_mask = np.isfinite(lows)
-    contact_mask = height_mask & speed_mask
+        stay_speed_mask = np.isfinite(lows)
+    enter_mask = height_mask & speed_mask
+    stay_mask = stay_height_mask & stay_speed_mask
 
     source_contacts_used = False
     source_contact_ratio = [0.0, 0.0]
@@ -933,15 +990,30 @@ def _foot_contact_analysis(
             source_height_mask = np.isfinite(lows) & (lows <= ground_y + contact_height * 1.25)
             if contact_velocity is not None and contact_velocity > 0.0:
                 source_speed_mask = np.isfinite(speeds) & (speeds <= contact_velocity * 1.75)
+                source_stay_speed_mask = np.isfinite(speeds) & (speeds <= contact_velocity * 2.5)
             else:
                 source_speed_mask = np.isfinite(lows)
-            contact_mask = contact_mask | (
+                source_stay_speed_mask = np.isfinite(lows)
+            source_enter = (
                 source_mask
                 & usable.reshape(1, 2)
                 & source_height_mask
                 & source_speed_mask
             )
-    contact_mask = np.nan_to_num(contact_mask, nan=False).astype(bool)
+            source_stay = (
+                source_mask
+                & usable.reshape(1, 2)
+                & (np.isfinite(lows) & (lows <= ground_y + contact_height * 1.7))
+                & source_stay_speed_mask
+            )
+            enter_mask = enter_mask | source_enter
+            stay_mask = stay_mask | source_stay
+    contact_mask = _stabilize_contact_mask(
+        np.nan_to_num(enter_mask, nan=False).astype(bool),
+        np.nan_to_num(stay_mask, nan=False).astype(bool),
+        min_frames=2,
+        max_gap_frames=2,
+    )
     support_mask = contact_mask.any(axis=1)
     return FootContactAnalysis(
         centers=centers,
@@ -1651,16 +1723,26 @@ def _apply_grounded_foot_ik(
                 np.nanmedian(centers[valid_center, 1] - lows[valid_center])
             )
 
+    support_segment_count = 0
+    internal_split_count = 0
     for side_index, side in enumerate(sides):
         calibration = calibration_by_side.get(side)
         if calibration is None:
             continue
-        side_segments: list[tuple[int, int]] = []
-        for start, end in _contiguous_segments(support_mask[:, side_index]):
-            side_segments.extend(
-                _split_long_segment(start, end, max(2, options.foot_support_max_frames))
+        side_segments: list[tuple[int, int, int, int]] = []
+        for support_start, support_end in _contiguous_segments(support_mask[:, side_index]):
+            support_segment_count += 1
+            split_segments = _split_long_segment(
+                support_start,
+                support_end,
+                max(2, options.foot_support_max_frames),
             )
-        for start, end in side_segments:
+            internal_split_count += max(0, len(split_segments) - 1)
+            side_segments.extend(
+                (start, end, support_start, support_end)
+                for start, end in split_segments
+            )
+        for start, end, support_start, support_end in side_segments:
             if end - start + 1 < 2:
                 continue
             centers = analysis.centers[start : end + 1, side_index]
@@ -1683,10 +1765,29 @@ def _apply_grounded_foot_ik(
             score[~valid] = np.inf
             anchor_frame = int(start + np.argmin(score))
             anchor_center = np.array([anchor_xy[0], target_center_y, anchor_xy[1]], dtype=np.float64)
+            anchor_local = local_quats_by_frame[anchor_frame]
+            anchor_globals = node_global_matrices(gltf, anchor_local)
+            anchor_ankle = anchor_globals[skin.joints[calibration.ankle]][:3, 3]
+            if calibration.toe is not None:
+                anchor_toe = anchor_globals[skin.joints[calibration.toe]][:3, 3]
+                anchor_current_center = (anchor_ankle + anchor_toe) * 0.5
+            else:
+                anchor_current_center = anchor_ankle
+            anchor_center_to_ankle = anchor_current_center - anchor_ankle
+            anchor_forward = _body_forward_from_globals(
+                anchor_globals,
+                gltf,
+                skin,
+                joint_by_name,
+            )
+            if anchor_forward is None:
+                anchor_forward = calibration.rest_contact_toe_global
             applied_segments.append(
                 {
                     "start": int(start),
                     "end": int(end),
+                    "support_start": int(support_start),
+                    "support_end": int(support_end),
                     "anchor_frame": anchor_frame,
                     "side": side,
                 }
@@ -1695,21 +1796,14 @@ def _apply_grounded_foot_ik(
             for frame_index in range(start, end + 1):
                 weight = _edge_blend_weight(
                     frame_index,
-                    start,
-                    end,
+                    support_start,
+                    support_end,
                     len(local_quats_by_frame),
                     options.foot_lock_blend_frames,
                 )
                 if weight <= 0.0:
                     continue
                 local = local_quats_by_frame[frame_index]
-                globals_ = node_global_matrices(gltf, local)
-                ankle = globals_[skin.joints[calibration.ankle]][:3, 3]
-                if calibration.toe is not None:
-                    toe = globals_[skin.joints[calibration.toe]][:3, 3]
-                    current_center = (ankle + toe) * 0.5
-                else:
-                    current_center = ankle
                 root_offset = _root_offset(
                     clip,
                     frame_index,
@@ -1721,10 +1815,7 @@ def _apply_grounded_foot_ik(
                     normalizer=normalizer,
                     root_offset=root_offset,
                 )
-                target_ankle = target_center - (current_center - ankle)
-                desired_forward = _body_forward_from_globals(globals_, gltf, skin, joint_by_name)
-                if desired_forward is None:
-                    desired_forward = calibration.rest_contact_toe_global
+                target_ankle = target_center - anchor_center_to_ankle
                 if _apply_leg_ik_target(
                     local=local,
                     gltf=gltf,
@@ -1732,7 +1823,7 @@ def _apply_grounded_foot_ik(
                     calibration=calibration,
                     target_ankle=target_ankle,
                     weight=weight,
-                    desired_toe_direction=desired_forward,
+                    desired_toe_direction=anchor_forward,
                     local_rest_rot=local_rest_rot,
                 ):
                     ik_frames.add(frame_index)
@@ -1751,6 +1842,10 @@ def _apply_grounded_foot_ik(
         },
         "max_airborne_gap_before": _max_airborne_gap(analysis.contact_mask),
         "max_airborne_gap_after": _max_airborne_gap(support_mask),
+        "support_segment_count": support_segment_count,
+        "internal_split_count": internal_split_count,
+        "contact_switches_before": int(np.abs(np.diff(analysis.contact_mask.astype(np.int8), axis=0)).sum()),
+        "contact_switches_after": int(np.abs(np.diff(support_mask.astype(np.int8), axis=0)).sum()),
         "source_contacts_used": analysis.source_contacts_used,
         "source_contact_ratio": analysis.source_contact_ratio,
         "strategy": (
@@ -1993,7 +2088,14 @@ def retarget_motion_to_avatar(
         if air_report.get("guided_frames", 0) > 0:
             local_quats_by_frame = build_local_quats_by_frame(leg_guides)
 
-    if options.foot_contact_lock and options.foot_orientation_lock:
+    grounded_foot_ik_expected = options.grounded_foot_ik and leg_ik_enabled
+    if options.foot_contact_lock and options.foot_orientation_lock and grounded_foot_ik_expected:
+        pre_postprocess["foot_orientation_lock"] = {
+            "enabled": True,
+            "locked_frames": 0,
+            "reason": "handled inside grounded foot IK support segments",
+        }
+    elif options.foot_contact_lock and options.foot_orientation_lock:
         rough_frames = _build_frame_geometries(
             gltf=gltf,
             skin=skin,

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -58,6 +58,11 @@ SMPL_LEG_JOINTS = {
     "Right": {"hip": 2, "knee": 5, "ankle": 8, "toe": 11},
 }
 
+SMPL_ARM_JOINTS = {
+    "Left": {"shoulder": 16, "elbow": 18, "wrist": 20},
+    "Right": {"shoulder": 17, "elbow": 19, "wrist": 21},
+}
+
 GLTF_UP = np.array([0.0, 0.0, 1.0], dtype=np.float64)
 SOURCE_TO_AVATAR_AXES = np.array(
     [
@@ -103,6 +108,7 @@ class RetargetOptions:
     material_roughness: float = 0.88
     detect_texture_alpha: bool = True
     calibrated_leg_ik: bool = True
+    calibrated_arm_ik: bool = True
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
     procedural_running_arm_swing: bool = False
@@ -658,6 +664,103 @@ def _apply_calibrated_leg_ik(
                 )
                 foot_delta = local_rest_rot[calibration.ankle].inv() * knee_global_rot.inv() * desired_foot_rot
                 local[calibration.ankle] = foot_delta.as_quat()
+
+    return local
+
+
+def _apply_calibrated_arm_ik(
+    *,
+    local: np.ndarray,
+    source_joints: np.ndarray,
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    calibrations: list[ArmCalibration],
+) -> np.ndarray:
+    if not calibrations:
+        return local
+
+    skin = gltf.skins[0]
+    source = _source_to_avatar_axes(source_joints.astype(np.float64))
+    current_globals = node_global_matrices(gltf, local)
+    source_basis = _source_body_basis(source)
+    target_basis = _target_body_basis_from_globals(current_globals, skin, joint_by_name)
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index)
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+
+    for calibration in calibrations:
+        source_map = SMPL_ARM_JOINTS[calibration.side]
+        source_shoulder = source[source_map["shoulder"]]
+        source_elbow = source[source_map["elbow"]]
+        source_wrist = source[source_map["wrist"]]
+
+        source_upper_len = float(np.linalg.norm(source_elbow - source_shoulder))
+        source_lower_len = float(np.linalg.norm(source_wrist - source_elbow))
+        source_chain_len = source_upper_len + source_lower_len
+        if source_chain_len < 1e-8:
+            continue
+
+        source_direction = _source_body_relative_direction(
+            source_wrist - source_shoulder,
+            source_body_basis=source_basis,
+            target_body_basis=target_basis,
+        )
+        if source_direction is None:
+            continue
+        reach_ratio = float(np.linalg.norm(source_wrist - source_shoulder) / source_chain_len)
+        reach_ratio = float(np.clip(reach_ratio, 0.20, 0.985))
+
+        parent_rot = (
+            _rotation_from_matrix(current_globals[calibration.parent_node])
+            if calibration.parent_node is not None
+            else Rotation.identity()
+        )
+        source_pole = _limb_pole(source_shoulder, source_elbow, source_wrist)
+        pole = None
+        if source_basis is not None and target_basis is not None:
+            pole = _projected_unit(target_basis @ (source_basis.T @ source_pole), source_direction)
+        if pole is None:
+            pole = _projected_unit(source_pole, source_direction)
+        if pole is None:
+            pole = parent_rot.apply(calibration.rest_pole_parent_local)
+            pole = _projected_unit(pole, source_direction)
+        if pole is None:
+            pole = _fallback_pole(source_direction)
+
+        shoulder_pos = current_globals[skin.joints[calibration.upper]][:3, 3]
+        elbow_pos, wrist_pos = _two_bone_knee_position(
+            shoulder_pos,
+            source_direction,
+            pole,
+            upper_len=calibration.upper_len,
+            lower_len=calibration.lower_len,
+            reach_ratio=reach_ratio,
+        )
+
+        desired_upper_rot = _basis_rotation(
+            calibration.rest_upper_local,
+            calibration.rest_pole_upper_local,
+            elbow_pos - shoulder_pos,
+            pole,
+        )
+        upper_delta = local_rest_rot[calibration.upper].inv() * parent_rot.inv() * desired_upper_rot
+        local[calibration.upper] = upper_delta.as_quat()
+
+        upper_global_rot = parent_rot * local_rest_rot[calibration.upper] * upper_delta
+        desired_forearm_rot = _basis_rotation(
+            calibration.rest_lower_local,
+            calibration.rest_pole_forearm_local,
+            wrist_pos - elbow_pos,
+            pole,
+        )
+        forearm_delta = (
+            local_rest_rot[calibration.forearm].inv()
+            * upper_global_rot.inv()
+            * desired_forearm_rot
+        )
+        local[calibration.forearm] = forearm_delta.as_quat()
+        local[calibration.hand] = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
 
     return local
 
@@ -2404,6 +2507,7 @@ def retarget_motion_to_avatar(
     leg_calibrations = _leg_calibrations(gltf, joint_by_name, rest_globals)
     arm_calibrations = _arm_calibrations(gltf, joint_by_name, rest_globals)
     leg_ik_enabled = options.calibrated_leg_ik and clip.posed_joints is not None and bool(leg_calibrations)
+    arm_ik_enabled = options.calibrated_arm_ik and clip.posed_joints is not None and bool(arm_calibrations)
 
     rest_vertices = deform_skinned_primitives(gltf, rest_joint_deltas)
     normalizer = VertexNormalizer.from_vertices(
@@ -2438,6 +2542,14 @@ def retarget_motion_to_avatar(
                         body_relative=options.body_relative_leg_ik,
                         leg_guide=leg_guides[frame_index] if leg_guides is not None else None,
                     )
+                if arm_ik_enabled:
+                    local_quats = _apply_calibrated_arm_ik(
+                        local=local_quats,
+                        source_joints=clip.posed_joints[frame_index],
+                        gltf=gltf,
+                        joint_by_name=joint_by_name,
+                        calibrations=arm_calibrations,
+                    )
             quats_by_frame.append(local_quats)
         return quats_by_frame
 
@@ -2445,6 +2557,7 @@ def retarget_motion_to_avatar(
 
     pre_postprocess: dict[str, Any] = {
         "airborne_leg_stabilization": {"enabled": False},
+        "calibrated_arm_ik": {"enabled": arm_ik_enabled},
         "torso_counter_rotation": {"enabled": False},
         "running_arm_swing": {"enabled": False},
         "foot_orientation_lock": {"enabled": False},
@@ -2588,6 +2701,11 @@ def retarget_motion_to_avatar(
             "legs": [calibration.side for calibration in leg_calibrations],
             "body_relative": options.body_relative_leg_ik,
         },
+        "arm_ik": {
+            "enabled": arm_ik_enabled,
+            "strategy": "calibrated two-bone IK from SMPL posed shoulder/elbow/wrist positions",
+            "arms": [calibration.side for calibration in arm_calibrations],
+        },
         "postprocess": postprocess,
     }
     (output_dir / "skeleton.json").write_text(json.dumps(skeleton, indent=2), encoding="utf-8")
@@ -2603,7 +2721,7 @@ def retarget_motion_to_avatar(
         "appearance_strategy": "preserve original ViCo/Mixamo skinned GLB mesh, UVs, skin weights, and textures",
         "retarget_strategy": (
             "map SMPL-22/GEM/Kimodo local rotations to compatible ViCo/Mixamo skin joints; "
-            "when posed joints are available, solve calibrated two-bone leg IK using the target rig knee pole; "
+            "when posed joints are available, solve calibrated two-bone leg and arm IK using target rig poles; "
             "body-relative leg mapping and airborne leg stabilization are experimental opt-in modes; "
             "optionally stabilize root yaw and lock support feet during contact/landing"
         ),
@@ -2638,6 +2756,7 @@ def retarget_motion_to_avatar(
         "max_top_y": max(item["max"][1] for item in bounds),
         "max_height": max(item["max"][1] - item["min"][1] for item in bounds),
         "leg_ik": skeleton["leg_ik"],
+        "arm_ik": skeleton["arm_ik"],
         "postprocess": postprocess,
     }
     return report

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -112,6 +112,9 @@ class RetargetOptions:
     running_arm_side_ratio: float = 0.055
     running_arm_reach_min: float = 0.46
     running_arm_reach_max: float = 0.68
+    locomotion_torso_counter_rotation: bool = True
+    torso_counter_rotation_degrees: float = 7.0
+    torso_counter_rotation_strength: float = 0.45
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
     hair_shell_thickness: float = 0.006
@@ -1599,6 +1602,74 @@ def _apply_procedural_running_arm_swing(
     }
 
 
+def _apply_locomotion_torso_counter_rotation(
+    *,
+    local_quats_by_frame: list[np.ndarray],
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    clip: MotionClip,
+    prompt: str,
+    options: RetargetOptions,
+) -> dict[str, Any]:
+    if not options.locomotion_torso_counter_rotation:
+        return {"enabled": False, "reason": "disabled"}
+    if not _prompt_requests_running_arm_swing(prompt):
+        return {"enabled": False, "reason": "prompt is not locomotion-like"}
+    frame_count = len(local_quats_by_frame)
+    if frame_count == 0:
+        return {"enabled": True, "frames_adjusted": 0, "reason": "empty clip"}
+
+    skin = gltf.skins[0]
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index)
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+    phase_signal, phase_report = _source_leg_phase_signal(clip, frame_count)
+    max_angle = np.radians(float(max(options.torso_counter_rotation_degrees, 0.0)))
+    strength = float(np.clip(options.torso_counter_rotation_strength, 0.0, 1.0))
+    channels = (
+        ("Spine", -0.20),
+        ("Spine1", -0.30),
+        ("Spine2", -0.38),
+        ("LeftShoulder", -0.16),
+        ("RightShoulder", -0.16),
+    )
+    applied_channels = 0
+    adjusted_frames: set[int] = set()
+
+    for frame_index, local in enumerate(local_quats_by_frame):
+        phase = float(np.clip(phase_signal[frame_index], -1.0, 1.0))
+        if abs(phase) < 1e-5:
+            continue
+        for name, weight in channels:
+            skin_index = joint_by_name.get(name)
+            if skin_index is None or skin_index not in local_rest_rot:
+                continue
+            local_up = local_rest_rot[skin_index].inv().apply(GLTF_UP)
+            local_up_unit = _safe_unit(local_up)
+            if local_up_unit is None:
+                continue
+            angle = phase * max_angle * strength * weight
+            offset = Rotation.from_rotvec(local_up_unit * angle)
+            current = Rotation.from_quat(local[skin_index])
+            local[skin_index] = (offset * current).as_quat()
+            applied_channels += 1
+            adjusted_frames.add(frame_index)
+
+    return {
+        "enabled": True,
+        "frames_adjusted": len(adjusted_frames),
+        "channels_adjusted": applied_channels,
+        "strength": strength,
+        "max_degrees": float(options.torso_counter_rotation_degrees),
+        "phase": phase_report,
+        "strategy": (
+            "add a small leg-phase-driven counter-yaw to spine/chest/shoulders before arm cleanup, "
+            "leaving root, pelvis, and legs untouched"
+        ),
+    }
+
+
 def _apply_foot_contact_lock(
     frames: list[FrameGeometry],
     joint_by_name: dict[str, int],
@@ -2374,6 +2445,7 @@ def retarget_motion_to_avatar(
 
     pre_postprocess: dict[str, Any] = {
         "airborne_leg_stabilization": {"enabled": False},
+        "torso_counter_rotation": {"enabled": False},
         "running_arm_swing": {"enabled": False},
         "foot_orientation_lock": {"enabled": False},
         "grounded_foot_ik": {"enabled": False},
@@ -2396,6 +2468,15 @@ def retarget_motion_to_avatar(
         pre_postprocess["airborne_leg_stabilization"] = air_report
         if air_report.get("guided_frames", 0) > 0:
             local_quats_by_frame = build_local_quats_by_frame(leg_guides)
+
+    pre_postprocess["torso_counter_rotation"] = _apply_locomotion_torso_counter_rotation(
+        local_quats_by_frame=local_quats_by_frame,
+        gltf=gltf,
+        joint_by_name=joint_by_name,
+        clip=clip,
+        prompt=prompt,
+        options=options,
+    )
 
     pre_postprocess["running_arm_swing"] = _apply_procedural_running_arm_swing(
         local_quats_by_frame=local_quats_by_frame,

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -105,14 +105,14 @@ class RetargetOptions:
     calibrated_leg_ik: bool = True
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
-    procedural_running_arm_swing: bool = True
+    procedural_running_arm_swing: bool = False
     running_arm_swing_strength: float = 0.35
     running_arm_forward_ratio: float = 0.52
     running_arm_drop_ratio: float = 0.50
     running_arm_side_ratio: float = 0.055
     running_arm_reach_min: float = 0.46
     running_arm_reach_max: float = 0.68
-    locomotion_torso_counter_rotation: bool = True
+    locomotion_torso_counter_rotation: bool = False
     torso_counter_rotation_degrees: float = 7.0
     torso_counter_rotation_strength: float = 0.45
     solidify_shell: bool = True

--- a/src/havln3/retarget.py
+++ b/src/havln3/retarget.py
@@ -105,6 +105,8 @@ class RetargetOptions:
     calibrated_leg_ik: bool = True
     body_relative_leg_ik: bool = False
     prefer_joint_position_ik: bool = False
+    procedural_running_arm_swing: bool = True
+    running_arm_swing_strength: float = 0.88
     solidify_shell: bool = True
     body_shell_thickness: float = 0.018
     hair_shell_thickness: float = 0.006
@@ -129,6 +131,22 @@ class LegCalibration:
     rest_toe_local: np.ndarray | None
     rest_foot_up_local: np.ndarray | None
     rest_contact_toe_global: np.ndarray | None
+
+
+@dataclass(frozen=True)
+class ArmCalibration:
+    side: str
+    upper: int
+    forearm: int
+    hand: int
+    parent_node: int | None
+    upper_len: float
+    lower_len: float
+    rest_upper_local: np.ndarray
+    rest_lower_local: np.ndarray
+    rest_pole_parent_local: np.ndarray
+    rest_pole_upper_local: np.ndarray
+    rest_pole_forearm_local: np.ndarray
 
 
 @dataclass
@@ -391,6 +409,65 @@ def _leg_calibrations(
                 rest_toe_local=rest_rotations[ankle].inv().apply(rest_toe) if rest_toe is not None else None,
                 rest_foot_up_local=rest_rotations[ankle].inv().apply(GLTF_UP) if toe is not None else None,
                 rest_contact_toe_global=rest_contact_toe,
+            )
+        )
+    return calibrations
+
+
+def _arm_calibrations(
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    rest_globals: list[np.ndarray],
+) -> list[ArmCalibration]:
+    skin = gltf.skins[0]
+    parents = _node_parent_indices(gltf)
+    rest_positions = np.stack([rest_globals[joint][:3, 3] for joint in skin.joints])
+    rest_rotations = {
+        skin_index: _rotation_from_matrix(rest_globals[node_index])
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+    body_basis = _target_body_basis_from_globals(rest_globals, skin, joint_by_name)
+    rest_side = body_basis[:, 0] if body_basis is not None else np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    rest_forward = body_basis[:, 2] if body_basis is not None else np.array([0.0, 1.0, 0.0], dtype=np.float64)
+
+    calibrations: list[ArmCalibration] = []
+    for side, sign in (("Left", -1.0), ("Right", 1.0)):
+        upper = joint_by_name.get(f"{side}Arm")
+        forearm = joint_by_name.get(f"{side}ForeArm")
+        hand = joint_by_name.get(f"{side}Hand")
+        if upper is None or forearm is None or hand is None:
+            continue
+
+        upper_pos = rest_positions[upper]
+        forearm_pos = rest_positions[forearm]
+        hand_pos = rest_positions[hand]
+        rest_upper = forearm_pos - upper_pos
+        rest_lower = hand_pos - forearm_pos
+        upper_len = float(np.linalg.norm(rest_upper))
+        lower_len = float(np.linalg.norm(rest_lower))
+        if upper_len < 1e-8 or lower_len < 1e-8:
+            continue
+
+        parent_node = parents.get(skin.joints[upper])
+        parent_rot = _rotation_from_matrix(rest_globals[parent_node]) if parent_node is not None else Rotation.identity()
+        pole = _projected_unit(rest_forward, rest_side * sign)
+        if pole is None:
+            pole = _fallback_pole(rest_side * sign)
+
+        calibrations.append(
+            ArmCalibration(
+                side=side,
+                upper=upper,
+                forearm=forearm,
+                hand=hand,
+                parent_node=parent_node,
+                upper_len=upper_len,
+                lower_len=lower_len,
+                rest_upper_local=rest_rotations[upper].inv().apply(rest_upper),
+                rest_lower_local=rest_rotations[forearm].inv().apply(rest_lower),
+                rest_pole_parent_local=parent_rot.inv().apply(pole),
+                rest_pole_upper_local=rest_rotations[upper].inv().apply(pole),
+                rest_pole_forearm_local=rest_rotations[forearm].inv().apply(pole),
             )
         )
     return calibrations
@@ -1292,6 +1369,221 @@ def _airborne_leg_guides(
     }
 
 
+def _prompt_requests_running_arm_swing(prompt: str) -> bool:
+    text = prompt.lower()
+    locomotion_words = (
+        "run",
+        "running",
+        "jog",
+        "jogging",
+        "walk",
+        "walking",
+        "circle",
+        "绕圈",
+        "小圈",
+        "跑",
+        "慢跑",
+        "走",
+    )
+    return any(word in text for word in locomotion_words)
+
+
+def _moving_average(values: np.ndarray, radius: int = 2) -> np.ndarray:
+    if radius <= 0 or len(values) == 0:
+        return values
+    smoothed = values.copy()
+    for index in range(len(values)):
+        start = max(0, index - radius)
+        end = min(len(values), index + radius + 1)
+        smoothed[index] = float(np.mean(values[start:end]))
+    return smoothed
+
+
+def _source_leg_phase_signal(clip: MotionClip, frame_count: int) -> tuple[np.ndarray, dict[str, Any]]:
+    signal = np.zeros(frame_count, dtype=np.float64)
+    valid = np.zeros(frame_count, dtype=bool)
+    if clip.posed_joints is not None:
+        for frame_index in range(min(frame_count, len(clip.posed_joints))):
+            source = _source_to_avatar_axes(clip.posed_joints[frame_index].astype(np.float64))
+            basis = _source_body_basis(source)
+            if basis is None:
+                continue
+            hips = source[0]
+            left_ankle = source[SMPL_LEG_JOINTS["Left"]["ankle"]]
+            right_ankle = source[SMPL_LEG_JOINTS["Right"]["ankle"]]
+            left_local = basis.T @ (left_ankle - hips)
+            right_local = basis.T @ (right_ankle - hips)
+            signal[frame_index] = float(left_local[2] - right_local[2])
+            valid[frame_index] = True
+
+    if valid.any():
+        valid_indices = np.flatnonzero(valid)
+        if len(valid_indices) < frame_count:
+            all_indices = np.arange(frame_count)
+            signal = np.interp(all_indices, valid_indices, signal[valid_indices])
+        signal = signal - float(np.mean(signal))
+        amplitude = float(np.nanpercentile(np.abs(signal), 90.0))
+        source = "posed_joints"
+    else:
+        cycles = max(2.0, frame_count / 36.0)
+        signal = np.sin(np.linspace(0.0, cycles * 2.0 * np.pi, frame_count, endpoint=False))
+        amplitude = 1.0
+        source = "synthetic_cycle"
+
+    if amplitude < 1e-6:
+        cycles = max(2.0, frame_count / 36.0)
+        signal = np.sin(np.linspace(0.0, cycles * 2.0 * np.pi, frame_count, endpoint=False))
+        amplitude = 1.0
+        source = "synthetic_cycle"
+
+    normalized = np.clip(signal / amplitude, -1.0, 1.0)
+    normalized = _moving_average(normalized, radius=2)
+    return normalized, {
+        "source": source,
+        "valid_frames": int(valid.sum()),
+        "amplitude": float(amplitude),
+    }
+
+
+def _apply_procedural_running_arm_swing(
+    *,
+    local_quats_by_frame: list[np.ndarray],
+    gltf: GLTF2,
+    joint_by_name: dict[str, int],
+    calibrations: list[ArmCalibration],
+    clip: MotionClip,
+    prompt: str,
+    options: RetargetOptions,
+) -> dict[str, Any]:
+    if not options.procedural_running_arm_swing:
+        return {"enabled": False, "reason": "disabled"}
+    if not _prompt_requests_running_arm_swing(prompt):
+        return {"enabled": False, "reason": "prompt is not locomotion-like"}
+    if not calibrations:
+        return {"enabled": True, "frames_adjusted": 0, "reason": "missing arm calibration"}
+
+    frame_count = len(local_quats_by_frame)
+    if frame_count == 0:
+        return {"enabled": True, "frames_adjusted": 0, "reason": "empty clip"}
+
+    skin = gltf.skins[0]
+    local_rest_rot = {
+        skin_index: _local_rest_rotation(gltf, node_index)
+        for skin_index, node_index in enumerate(skin.joints)
+    }
+    phase_signal, phase_report = _source_leg_phase_signal(clip, frame_count)
+    strength = float(np.clip(options.running_arm_swing_strength, 0.0, 1.0))
+    adjusted_frames: set[int] = set()
+    adjusted_channels = 0
+
+    for frame_index, local in enumerate(local_quats_by_frame):
+        globals_ = node_global_matrices(gltf, local)
+        body_basis = _target_body_basis_from_globals(globals_, skin, joint_by_name)
+        if body_basis is None:
+            continue
+        side_axis = body_basis[:, 0]
+        up_axis = body_basis[:, 1]
+        forward_axis = body_basis[:, 2]
+
+        for calibration in calibrations:
+            side_sign = -1.0 if calibration.side == "Left" else 1.0
+            # Left arm moves backward when the left leg is forward; right arm mirrors it.
+            swing = (-phase_signal[frame_index] if calibration.side == "Left" else phase_signal[frame_index])
+            swing = float(np.clip(swing, -1.0, 1.0))
+            shoulder = globals_[skin.joints[calibration.upper]][:3, 3]
+            chain_len = calibration.upper_len + calibration.lower_len
+            hand_target = (
+                shoulder
+                + side_axis * side_sign * (0.11 * chain_len)
+                - up_axis * (0.72 * chain_len)
+                + forward_axis * (0.32 * chain_len * swing)
+            )
+            direction = _safe_unit(hand_target - shoulder)
+            if direction is None:
+                continue
+            pole_hint = side_axis * side_sign * 0.85 - up_axis * 0.15
+            pole = _projected_unit(pole_hint, direction)
+            if pole is None:
+                pole = _fallback_pole(direction)
+            reach_ratio = float(
+                np.clip(
+                    np.linalg.norm(hand_target - shoulder) / max(chain_len, 1e-8),
+                    0.56,
+                    0.86,
+                )
+            )
+            elbow, wrist = _two_bone_knee_position(
+                shoulder,
+                direction,
+                pole,
+                upper_len=calibration.upper_len,
+                lower_len=calibration.lower_len,
+                reach_ratio=reach_ratio,
+            )
+
+            parent_rot = (
+                _rotation_from_matrix(globals_[calibration.parent_node])
+                if calibration.parent_node is not None
+                else Rotation.identity()
+            )
+            desired_upper = elbow - shoulder
+            desired_upper_rot = _basis_rotation(
+                calibration.rest_upper_local,
+                calibration.rest_pole_upper_local,
+                desired_upper,
+                pole,
+            )
+            target_upper_delta = (
+                local_rest_rot[calibration.upper].inv()
+                * parent_rot.inv()
+                * desired_upper_rot
+            )
+            current_upper_delta = Rotation.from_quat(local[calibration.upper])
+            upper_delta = _blend_rotation(current_upper_delta, target_upper_delta, strength)
+            local[calibration.upper] = upper_delta.as_quat()
+
+            upper_global_rot = parent_rot * local_rest_rot[calibration.upper] * upper_delta
+            desired_lower = wrist - elbow
+            desired_forearm_rot = _basis_rotation(
+                calibration.rest_lower_local,
+                calibration.rest_pole_forearm_local,
+                desired_lower,
+                pole,
+            )
+            target_forearm_delta = (
+                local_rest_rot[calibration.forearm].inv()
+                * upper_global_rot.inv()
+                * desired_forearm_rot
+            )
+            current_forearm_delta = Rotation.from_quat(local[calibration.forearm])
+            local[calibration.forearm] = _blend_rotation(
+                current_forearm_delta,
+                target_forearm_delta,
+                strength,
+            ).as_quat()
+
+            current_hand_delta = Rotation.from_quat(local[calibration.hand])
+            local[calibration.hand] = _blend_rotation(
+                current_hand_delta,
+                Rotation.identity(),
+                strength * 0.55,
+            ).as_quat()
+            adjusted_channels += 3
+            adjusted_frames.add(frame_index)
+
+    return {
+        "enabled": True,
+        "frames_adjusted": len(adjusted_frames),
+        "channels_adjusted": adjusted_channels,
+        "strength": strength,
+        "phase": phase_report,
+        "strategy": (
+            "derive a reciprocal arm phase from Kimodo left/right ankle forward offsets, "
+            "then solve target-rig two-bone shoulder-elbow-hand IK with hands close to the torso"
+        ),
+    }
+
+
 def _apply_foot_contact_lock(
     frames: list[FrameGeometry],
     joint_by_name: dict[str, int],
@@ -2024,6 +2316,7 @@ def retarget_motion_to_avatar(
     rest_joint_deltas = identity_quaternions(len(skin.joints))
     rest_globals = node_global_matrices(gltf, rest_joint_deltas)
     leg_calibrations = _leg_calibrations(gltf, joint_by_name, rest_globals)
+    arm_calibrations = _arm_calibrations(gltf, joint_by_name, rest_globals)
     leg_ik_enabled = options.calibrated_leg_ik and clip.posed_joints is not None and bool(leg_calibrations)
 
     rest_vertices = deform_skinned_primitives(gltf, rest_joint_deltas)
@@ -2066,6 +2359,7 @@ def retarget_motion_to_avatar(
 
     pre_postprocess: dict[str, Any] = {
         "airborne_leg_stabilization": {"enabled": False},
+        "running_arm_swing": {"enabled": False},
         "foot_orientation_lock": {"enabled": False},
         "grounded_foot_ik": {"enabled": False},
     }
@@ -2087,6 +2381,16 @@ def retarget_motion_to_avatar(
         pre_postprocess["airborne_leg_stabilization"] = air_report
         if air_report.get("guided_frames", 0) > 0:
             local_quats_by_frame = build_local_quats_by_frame(leg_guides)
+
+    pre_postprocess["running_arm_swing"] = _apply_procedural_running_arm_swing(
+        local_quats_by_frame=local_quats_by_frame,
+        gltf=gltf,
+        joint_by_name=joint_by_name,
+        calibrations=arm_calibrations,
+        clip=clip,
+        prompt=prompt,
+        options=options,
+    )
 
     grounded_foot_ik_expected = options.grounded_foot_ik and leg_ik_enabled
     if options.foot_contact_lock and options.foot_orientation_lock and grounded_foot_ik_expected:

--- a/tests/havln3/test_avatar_action_pipeline.py
+++ b/tests/havln3/test_avatar_action_pipeline.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pygltflib import GLTF2
+
+from havln3.avatar_assets import select_avatar
+from havln3.pipeline import AvatarActionPipeline, AvatarActionRequest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AVATAR_ROOT = REPO_ROOT / "vico_assets_probe" / "models"
+KIMODO_SAMPLE = (
+    REPO_ROOT
+    / "local_experiments"
+    / "kimodo_motion_backflip_wave"
+    / "office_worker_backflip_then_wave_00.npz"
+)
+
+pytestmark = pytest.mark.skipif(
+    not AVATAR_ROOT.exists() or not KIMODO_SAMPLE.exists(),
+    reason="ViCo avatar probes and Kimodo sample motion are local asset fixtures",
+)
+
+
+def test_select_avatar_allows_strong_suit_match_with_solidified_alpha_atlas() -> None:
+    match, top = select_avatar(
+        "An office worker in a suit does a backflip and waves.",
+        AVATAR_ROOT,
+    )
+
+    assert match.asset.path.name == "mixamo_Joe_Anderson.glb"
+    assert top
+    assert {"office", "suit", "formal"} <= match.asset.tags
+    assert match.asset.alpha_material_count <= 1
+
+
+def test_pipeline_exports_textured_frames_and_skeleton(tmp_path: Path) -> None:
+    result = AvatarActionPipeline().run(
+        AvatarActionRequest(
+            prompt="An office worker in a suit does a backflip and waves.",
+            output_root=tmp_path,
+            avatar_root=AVATAR_ROOT,
+            motion_npz=KIMODO_SAMPLE,
+            asset_name="test_office_backflip_wave",
+            frames=2,
+        )
+    )
+
+    assert result.asset_dir.exists()
+    assert len(list(result.asset_dir.glob("frame*.glb"))) == 2
+    assert len(list(result.asset_dir.glob("frame*.object_config.json"))) == 2
+    assert result.skeleton_path.exists()
+    assert result.report_path.exists()
+
+    skeleton = json.loads(result.skeleton_path.read_text(encoding="utf-8"))
+    assert len(skeleton["joint_names"]) >= 60
+    assert len(skeleton["frames"]) == 2
+    assert len(skeleton["frames"][0]) == len(skeleton["joint_names"])
+    assert skeleton["leg_ik"]["enabled"] is True
+    assert skeleton["leg_ik"]["body_relative"] is False
+    assert "two-bone IK" in skeleton["leg_ik"]["strategy"]
+
+    frame = GLTF2().load(str(result.asset_dir / "frame000.glb"))
+    for material in frame.materials or []:
+        assert material.alphaMode != "BLEND"
+        assert material.doubleSided is True
+
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    assert report["selection"]["selected"]["path"].endswith("mixamo_Joe_Anderson.glb")

--- a/tests/havln3/test_motion_generation.py
+++ b/tests/havln3/test_motion_generation.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from havln3.motion import _generated_motion_candidates
+
+
+def test_generated_motion_candidates_find_kimodo_output_directory(tmp_path) -> None:
+    output_stem = tmp_path / "clean_standing_backflip"
+    output_stem.mkdir()
+    motion_path = output_stem / "clean_standing_backflip_00.npz"
+    amass_path = output_stem / "amass_00.npz"
+    motion_path.write_bytes(b"")
+    amass_path.write_bytes(b"")
+
+    assert _generated_motion_candidates(output_stem) == [(motion_path, amass_path)]

--- a/tests/havln3/test_motion_postprocess.py
+++ b/tests/havln3/test_motion_postprocess.py
@@ -7,6 +7,9 @@ from havln3.retarget import (
     FrameGeometry,
     _apply_foot_contact_lock,
     _apply_root_yaw_stabilization,
+    _expand_support_contact_mask,
+    _foot_contact_analysis,
+    _max_airborne_gap,
     _source_body_relative_direction,
 )
 
@@ -96,6 +99,51 @@ def test_foot_contact_lock_anchors_landing_foot_position() -> None:
     assert np.allclose(left_toe[[0, 2]], left_anchor[[0, 2]])
     assert left_toe[1] >= 0.0
     assert abs(frames[-1].vertices_by_primitive[0][:, 1].min() - 0.0) < 1e-6
+
+
+def test_support_contact_mask_expands_low_foot_gait_phases() -> None:
+    frames = []
+    for frame_index in range(36):
+        left_phase = np.sin((frame_index - 5) / 7.0 * np.pi)
+        right_phase = np.sin((frame_index - 12) / 7.0 * np.pi)
+        left_low = 0.03 + 0.08 * ((left_phase + 1.0) * 0.5)
+        right_low = 0.03 + 0.08 * ((right_phase + 1.0) * 0.5)
+        x = frame_index * 0.04
+        joints = np.array(
+            [
+                [x, 1.0, 0.0],
+                [x - 0.2, 0.8, 0.0],
+                [x + 0.2, 0.8, 0.0],
+                [x - 0.2, left_low, 0.0],
+                [x - 0.2, left_low, 0.2],
+                [x + 0.2, right_low, 0.0],
+                [x + 0.2, right_low, 0.2],
+            ],
+            dtype=np.float64,
+        )
+        frames.append(_frame(joints))
+
+    analysis = _foot_contact_analysis(
+        frames,
+        JOINTS,
+        ground_y=0.0,
+        contact_height=0.04,
+        contact_velocity=0.001,
+        use_source_contacts=False,
+    )
+    assert analysis is not None
+    expanded = _expand_support_contact_mask(
+        analysis,
+        fps=60,
+        ground_y=0.0,
+        contact_height=0.04,
+        min_segment_frames=6,
+        max_air_frames=4,
+    )
+
+    assert int(expanded.sum()) > int(analysis.contact_mask.sum())
+    assert _max_airborne_gap(expanded) <= 4
+    assert int((expanded.sum(axis=1) > 1).sum()) == 0
 
 
 def test_body_relative_leg_direction_follows_target_parent_frame() -> None:

--- a/tests/havln3/test_motion_postprocess.py
+++ b/tests/havln3/test_motion_postprocess.py
@@ -146,6 +146,39 @@ def test_support_contact_mask_expands_low_foot_gait_phases() -> None:
     assert int((expanded.sum(axis=1) > 1).sum()) == 0
 
 
+def test_foot_contact_analysis_hysteresis_fills_single_frame_contact_blip() -> None:
+    frames = []
+    left_lows = [0.02, 0.02, 0.05, 0.02, 0.02, 0.11, 0.11]
+    for frame_index, left_low in enumerate(left_lows):
+        x = frame_index * 0.01
+        joints = np.array(
+            [
+                [x, 1.0, 0.0],
+                [x - 0.2, 0.8, 0.0],
+                [x + 0.2, 0.8, 0.0],
+                [x - 0.2, left_low, 0.0],
+                [x - 0.2, left_low, 0.2],
+                [x + 0.2, 0.16, 0.0],
+                [x + 0.2, 0.16, 0.2],
+            ],
+            dtype=np.float64,
+        )
+        frames.append(_frame(joints))
+
+    analysis = _foot_contact_analysis(
+        frames,
+        JOINTS,
+        ground_y=0.0,
+        contact_height=0.03,
+        contact_velocity=None,
+        use_source_contacts=False,
+    )
+
+    assert analysis is not None
+    assert analysis.contact_mask[:5, 0].all()
+    assert not analysis.contact_mask[5:, 0].any()
+
+
 def test_body_relative_leg_direction_follows_target_parent_frame() -> None:
     source_parent = Rotation.from_euler("y", 90, degrees=True)
     target_parent = Rotation.from_euler("y", -45, degrees=True)

--- a/tests/havln3/test_motion_postprocess.py
+++ b/tests/havln3/test_motion_postprocess.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from havln3.retarget import (
+    FrameGeometry,
+    _apply_foot_contact_lock,
+    _apply_root_yaw_stabilization,
+    _source_body_relative_direction,
+)
+
+
+JOINTS = {
+    "Hips": 0,
+    "LeftUpLeg": 1,
+    "RightUpLeg": 2,
+    "LeftFoot": 3,
+    "LeftToeBase": 4,
+    "RightFoot": 5,
+    "RightToeBase": 6,
+}
+
+
+def _frame(joints: np.ndarray) -> FrameGeometry:
+    vertices = joints + np.array([0.0, -0.02, 0.0])
+    return FrameGeometry(vertices_by_primitive=[vertices.copy()], joints=joints.copy())
+
+
+def test_root_yaw_stabilization_keeps_initial_horizontal_facing() -> None:
+    frames = [
+        _frame(
+            np.array(
+                [
+                    [0.0, 1.0, 0.0],
+                    [-1.0, 1.0, 0.0],
+                    [1.0, 1.0, 0.0],
+                    [-1.0, 0.0, 0.0],
+                    [-1.0, 0.0, 0.2],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.2],
+                ]
+            )
+        ),
+        _frame(
+            np.array(
+                [
+                    [0.0, 1.0, 0.0],
+                    [0.0, 1.0, -1.0],
+                    [0.0, 1.0, 1.0],
+                    [0.0, 0.0, -1.0],
+                    [0.2, 0.0, -1.0],
+                    [0.0, 0.0, 1.0],
+                    [0.2, 0.0, 1.0],
+                ]
+            )
+        ),
+    ]
+
+    report = _apply_root_yaw_stabilization(frames, JOINTS)
+    stabilized_side = frames[1].joints[JOINTS["RightUpLeg"]] - frames[1].joints[JOINTS["LeftUpLeg"]]
+
+    assert report["frames_adjusted"] == 1
+    assert stabilized_side[0] > 1.9
+    assert abs(stabilized_side[2]) < 1e-6
+
+
+def test_foot_contact_lock_anchors_landing_foot_position() -> None:
+    frames = []
+    for foot_x in (0.0, 0.1, 0.2, 0.65):
+        joints = np.array(
+            [
+                [foot_x, 1.0, 0.0],
+                [foot_x - 0.2, 0.8, 0.0],
+                [foot_x + 0.2, 0.8, 0.0],
+                [foot_x - 0.2, 0.02, 0.0],
+                [foot_x - 0.2, 0.01, 0.2],
+                [foot_x + 0.2, 0.02, 0.0],
+                [foot_x + 0.2, 0.01, 0.2],
+            ],
+            dtype=np.float64,
+        )
+        frames.append(_frame(joints))
+
+    report = _apply_foot_contact_lock(
+        frames,
+        JOINTS,
+        ground_y=0.0,
+        contact_height=0.05,
+        blend_frames=0,
+    )
+    left_toe = frames[-1].joints[JOINTS["LeftToeBase"]]
+    left_anchor = frames[0].joints[JOINTS["LeftToeBase"]]
+
+    assert report["locked_frames"] == 4
+    assert np.allclose(left_toe[[0, 2]], left_anchor[[0, 2]])
+    assert left_toe[1] >= 0.0
+    assert abs(frames[-1].vertices_by_primitive[0][:, 1].min() - 0.0) < 1e-6
+
+
+def test_body_relative_leg_direction_follows_target_parent_frame() -> None:
+    source_parent = Rotation.from_euler("y", 90, degrees=True)
+    target_parent = Rotation.from_euler("y", -45, degrees=True)
+    source_local_leg = np.array([0.0, -1.0, 0.25], dtype=np.float64)
+    source_world_leg = source_parent.apply(source_local_leg)
+
+    mapped = _source_body_relative_direction(
+        source_world_leg,
+        source_global_rotations={0: source_parent},
+        source_parent_index=0,
+        target_parent_rotation=target_parent,
+    )
+
+    expected = target_parent.apply(source_local_leg / np.linalg.norm(source_local_leg))
+    assert mapped is not None
+    assert np.allclose(mapped, expected)
+    assert not np.allclose(mapped, source_world_leg / np.linalg.norm(source_world_leg))

--- a/tests/havln3/test_motion_postprocess.py
+++ b/tests/havln3/test_motion_postprocess.py
@@ -10,6 +10,7 @@ from havln3.retarget import (
     _expand_support_contact_mask,
     _foot_contact_analysis,
     _max_airborne_gap,
+    _prompt_requests_running_arm_swing,
     _source_body_relative_direction,
 )
 
@@ -196,3 +197,9 @@ def test_body_relative_leg_direction_follows_target_parent_frame() -> None:
     assert mapped is not None
     assert np.allclose(mapped, expected)
     assert not np.allclose(mapped, source_world_leg / np.linalg.norm(source_world_leg))
+
+
+def test_running_arm_swing_prompt_gate_matches_locomotion_only() -> None:
+    assert _prompt_requests_running_arm_swing("A suited person jogs around a small circle")
+    assert _prompt_requests_running_arm_swing("一个人绕小圈慢跑")
+    assert not _prompt_requests_running_arm_swing("A person sits and waves")

--- a/tests/havln3/test_motion_quality.py
+++ b/tests/havln3/test_motion_quality.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from havln3.motion import MotionClip
+from havln3.motion_quality import MotionQualityOptions, score_motion_clip
+
+
+def _synthetic_clip(angles: np.ndarray, *, fold_midair: bool = False) -> MotionClip:
+    frames = len(angles)
+    posed = np.zeros((frames, 22, 3), dtype=np.float64)
+    for frame_index, angle in enumerate(angles):
+        pelvis = np.array([0.0, 0.0, 1.0])
+        side = np.array([1.0, 0.0, 0.0])
+        up = np.array([0.0, np.sin(angle), np.cos(angle)])
+        forward = np.array([0.0, np.cos(angle), -np.sin(angle)])
+        posed_frame = np.zeros((22, 3), dtype=np.float64)
+        posed_frame[0] = pelvis
+        posed_frame[3] = pelvis + up * 0.25
+        posed_frame[6] = pelvis + up * 0.42
+        posed_frame[9] = pelvis + up * 0.58
+        posed_frame[12] = pelvis + up * 0.68
+        posed_frame[15] = pelvis + up * 0.82
+        posed_frame[13] = posed_frame[9] - side * 0.18
+        posed_frame[14] = posed_frame[9] + side * 0.18
+        posed_frame[16] = posed_frame[13] - side * 0.08 - up * 0.1
+        posed_frame[17] = posed_frame[14] + side * 0.08 - up * 0.1
+        posed_frame[18] = posed_frame[16] - side * 0.1 - up * 0.18
+        posed_frame[19] = posed_frame[17] + side * 0.1 - up * 0.18
+        posed_frame[20] = posed_frame[18] - side * 0.08 - up * 0.14
+        posed_frame[21] = posed_frame[19] + side * 0.08 - up * 0.14
+        posed_frame[1] = pelvis - side * 0.11 - up * 0.05
+        posed_frame[2] = pelvis + side * 0.11 - up * 0.05
+        tuck = np.sin(np.pi * frame_index / max(frames - 1, 1))
+        for side_name, sign, hip_index, knee_index, ankle_index, toe_index in (
+            ("Left", -1.0, 1, 4, 7, 10),
+            ("Right", 1.0, 2, 5, 8, 11),
+        ):
+            del side_name
+            hip = posed_frame[hip_index]
+            if fold_midair and abs(frame_index - frames // 2) <= 1:
+                ankle = posed_frame[15] - up * 0.04 + side * sign * 0.02
+                knee = (hip + ankle) * 0.5 + forward * 0.02
+            else:
+                leg_dir = -up * (1.0 - tuck * 0.45) + forward * (tuck * 0.45)
+                leg_dir = leg_dir / np.linalg.norm(leg_dir)
+                knee = hip + leg_dir * 0.38
+                ankle = hip + leg_dir * 0.76
+            posed_frame[knee_index] = knee
+            posed_frame[ankle_index] = ankle
+            posed_frame[toe_index] = ankle + forward * 0.12
+            if fold_midair and abs(frame_index - frames // 2) <= 1:
+                wrist_index = 20 if sign < 0 else 21
+                posed_frame[wrist_index] = ankle + side * sign * 0.01
+        posed[frame_index] = posed_frame
+    mats = np.tile(np.eye(3, dtype=np.float64), (frames, 22, 1, 1))
+    return MotionClip(
+        local_rot_mats=mats,
+        root_positions=np.zeros((frames, 3), dtype=np.float64),
+        posed_joints=posed,
+        foot_contacts=None,
+        source_path=Path("synthetic.npz"),
+    )
+
+
+def test_motion_quality_prefers_complete_backflip_over_partial_rotation() -> None:
+    full = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48))
+    partial = _synthetic_clip(np.concatenate([np.linspace(0.0, -1.0 * np.pi, 24), np.linspace(-1.0 * np.pi, 0.0, 24)]))
+
+    options = MotionQualityOptions(frames=48)
+    full_report = score_motion_clip(full, prompt="A person performs a clean standing backflip.", options=options)
+    partial_report = score_motion_clip(partial, prompt="A person performs a clean standing backflip.", options=options)
+
+    assert full_report.score > partial_report.score
+    assert full_report.metrics["backflip_total_degrees"] > 300
+    assert "backflip does not complete enough net rotation" in partial_report.reasons
+
+
+def test_motion_quality_penalizes_midair_body_fold() -> None:
+    clean = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48))
+    folded = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48), fold_midair=True)
+
+    options = MotionQualityOptions(frames=48)
+    clean_report = score_motion_clip(clean, prompt="A person performs a clean standing backflip.", options=options)
+    folded_report = score_motion_clip(folded, prompt="A person performs a clean standing backflip.", options=options)
+
+    assert clean_report.score > folded_report.score
+    assert folded_report.metrics["foot_head_distance_min_ratio"] < clean_report.metrics["foot_head_distance_min_ratio"]
+    assert "foot gets too close to head/face" in folded_report.reasons
+
+
+def test_motion_quality_penalizes_self_contact_tuck() -> None:
+    clean = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48))
+    folded = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48), fold_midair=True)
+
+    options = MotionQualityOptions(frames=48)
+    clean_report = score_motion_clip(clean, prompt="A person performs a clean standing backflip.", options=options)
+    folded_report = score_motion_clip(folded, prompt="A person performs a clean standing backflip.", options=options)
+
+    assert folded_report.metrics["hand_foot_clearance_min_ratio"] < clean_report.metrics["hand_foot_clearance_min_ratio"]
+    assert folded_report.metrics["limb_core_clearance_min_ratio"] < clean_report.metrics["limb_core_clearance_min_ratio"]
+    assert "hands and feet get too close during tuck" in folded_report.reasons
+    assert "limbs get too close to torso/head" in folded_report.reasons

--- a/tests/havln3/test_motion_quality.py
+++ b/tests/havln3/test_motion_quality.py
@@ -65,6 +65,69 @@ def _synthetic_clip(angles: np.ndarray, *, fold_midair: bool = False) -> MotionC
     )
 
 
+def _running_clip(*, wide_locked_arms: bool = False) -> MotionClip:
+    frames = 72
+    posed = np.zeros((frames, 22, 3), dtype=np.float64)
+    root_positions = np.zeros((frames, 3), dtype=np.float64)
+    side = np.array([1.0, 0.0, 0.0])
+    up = np.array([0.0, 0.0, 1.0])
+    forward = np.array([0.0, -1.0, 0.0])
+    for frame_index in range(frames):
+        phase = 2.0 * np.pi * frame_index / frames
+        root_positions[frame_index] = np.array([0.45 * np.cos(phase), 0.45 * np.sin(phase), 0.0])
+        pelvis = np.array([0.0, 0.0, 1.0])
+        frame = np.zeros((22, 3), dtype=np.float64)
+        frame[0] = pelvis
+        frame[3] = pelvis + up * 0.25
+        frame[6] = pelvis + up * 0.42
+        frame[9] = pelvis + up * 0.58
+        frame[12] = pelvis + up * 0.68
+        frame[15] = pelvis + up * 0.82
+        frame[13] = frame[9] - side * 0.18
+        frame[14] = frame[9] + side * 0.18
+        frame[16] = frame[13] - side * 0.08 - up * 0.07
+        frame[17] = frame[14] + side * 0.08 - up * 0.07
+
+        for sign, hip_index, knee_index, ankle_index, toe_index in (
+            (-1.0, 1, 4, 7, 10),
+            (1.0, 2, 5, 8, 11),
+        ):
+            leg_phase = np.sin(phase) if sign < 0 else -np.sin(phase)
+            hip = pelvis + side * sign * 0.11 - up * 0.05
+            knee = hip - up * 0.36 + forward * (0.08 * leg_phase)
+            ankle = hip - up * 0.72 + forward * (0.18 * leg_phase)
+            frame[hip_index] = hip
+            frame[knee_index] = knee
+            frame[ankle_index] = ankle
+            frame[toe_index] = ankle + forward * 0.12
+
+        for sign, shoulder_index, elbow_index, hand_index in (
+            (-1.0, 16, 18, 20),
+            (1.0, 17, 19, 21),
+        ):
+            shoulder = frame[shoulder_index]
+            if wide_locked_arms:
+                elbow = shoulder + side * sign * 0.28 - up * 0.02
+                hand = shoulder + side * sign * 0.58 - up * 0.03
+            else:
+                arm_phase = -np.sin(phase) if sign < 0 else np.sin(phase)
+                elbow = shoulder + side * sign * 0.02 - up * 0.20 + forward * (0.05 * arm_phase)
+                hand = elbow - side * sign * 0.02 - up * 0.16 + forward * (0.14 * arm_phase)
+            frame[elbow_index] = elbow
+            frame[hand_index] = hand
+
+        posed[frame_index] = frame
+
+    mats = np.tile(np.eye(3, dtype=np.float64), (frames, 22, 1, 1))
+    return MotionClip(
+        local_rot_mats=mats,
+        root_positions=root_positions,
+        posed_joints=posed,
+        foot_contacts=None,
+        source_path=Path("synthetic_running.npz"),
+    )
+
+
 def test_motion_quality_prefers_complete_backflip_over_partial_rotation() -> None:
     full = _synthetic_clip(np.linspace(0.0, -2.0 * np.pi, 48))
     partial = _synthetic_clip(np.concatenate([np.linspace(0.0, -1.0 * np.pi, 24), np.linspace(-1.0 * np.pi, 0.0, 24)]))
@@ -103,3 +166,18 @@ def test_motion_quality_penalizes_self_contact_tuck() -> None:
     assert folded_report.metrics["limb_core_clearance_min_ratio"] < clean_report.metrics["limb_core_clearance_min_ratio"]
     assert "hands and feet get too close during tuck" in folded_report.reasons
     assert "limbs get too close to torso/head" in folded_report.reasons
+
+
+def test_motion_quality_penalizes_running_without_natural_arm_swing() -> None:
+    natural = _running_clip()
+    wide_locked = _running_clip(wide_locked_arms=True)
+
+    options = MotionQualityOptions(frames=72)
+    natural_report = score_motion_clip(natural, prompt="A person jogs around a small circle.", options=options)
+    wide_report = score_motion_clip(wide_locked, prompt="A person jogs around a small circle.", options=options)
+
+    assert natural_report.score > wide_report.score
+    assert natural_report.metrics["arm_forward_range_ratio"] > wide_report.metrics["arm_forward_range_ratio"]
+    assert natural_report.metrics["arm_leg_counterphase"] > 0.8
+    assert "running arms do not swing forward/back enough" in wide_report.reasons
+    assert "running hands are held too wide from the torso" in wide_report.reasons


### PR DESCRIPTION
Adds the avatar action generation/retargeting pipeline and documentation for Kimodo/GEM motion scoring, calibrated two-bone leg IK, contact-aware foot locking, root yaw stabilization, and asset/texture handling.\n\nValidation:\n- PYTHONPATH=src pytest tests/havln3 -q (7 passed, 2 skipped)\n- PYTHONPATH=src python3 -m compileall src/havln3 scripts/generate_avatar_action.py scripts/score_kimodo_motions.py